### PR TITLE
Harden MVP upload, QR generation, and mobile gift viewer UX

### DIFF
--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -1,9 +1,166 @@
+:root {
+  color-scheme: light;
+  --bg: #f3f4f8;
+  --card: #ffffff;
+  --text: #101828;
+  --subtle: #475467;
+  --border: #d0d5dd;
+  --primary: #6d28d9;
+  --primary-dark: #5b21b6;
+  --error: #b42318;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: Arial, sans-serif;
-  padding: 20px;
+  margin: 0;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.card {
+  width: min(100%, 560px);
+  background: var(--card);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(16, 24, 40, 0.08);
+}
+
+h1,
+h2 {
+  margin: 0 0 12px;
+}
+
+.subtle {
+  margin-top: 0;
+  color: var(--subtle);
+}
+
+.gift-form {
+  display: grid;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+label {
+  text-align: left;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+textarea,
+input[type='file'] {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  font: inherit;
+  background: #fff;
+}
+
+textarea {
+  min-height: 110px;
+  resize: vertical;
+}
+
+button,
+.button-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 12px;
+  padding: 12px 18px;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+button:hover,
+.button-link:hover {
+  background: var(--primary-dark);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.status {
+  margin: 16px 0 0;
+  min-height: 20px;
+  color: var(--subtle);
+}
+
+.error {
+  color: var(--error);
+}
+
+.result {
+  margin-top: 18px;
+  display: grid;
+  gap: 12px;
+  justify-items: center;
+}
+
+.result img {
+  width: min(100%, 280px);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.gift-message {
+  margin-top: 16px;
+  font-size: 1.05rem;
+  text-align: center;
+  white-space: pre-wrap;
+}
+
+.gift-video {
+  margin-top: 10px;
+  width: 100%;
+  max-height: 50vh;
+  border-radius: 12px;
+  background: #000;
+}
+
+.back-link {
+  display: inline-block;
+  margin-bottom: 10px;
+  color: var(--subtle);
+  text-decoration: none;
+}
+
+.hero-card {
   text-align: center;
 }
-button {
-  padding: 10px 20px;
-  cursor: pointer;
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 560px) {
+  .card {
+    padding: 18px;
+    border-radius: 14px;
+  }
+
+  button,
+  .button-link {
+    width: 100%;
+  }
 }

--- a/client/index.html
+++ b/client/index.html
@@ -1,11 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Smart QR Gifting</title>
-  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body>
-  <h1>Smart QR Gifting MVP</h1>
-  <a href="upload.html">Create Gift</a>
+  <main class="page">
+    <section class="card hero-card">
+      <h1>Smart QR Gifting</h1>
+      <p class="subtle">Create a personalized gift page, attach a video, and share instantly with a scan.</p>
+      <a href="upload.html" class="button-link">Create a gift</a>
+    </section>
+  </main>
 </body>
 </html>

--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -1,16 +1,59 @@
-document.getElementById('uploadForm').addEventListener('submit', async (e) => {
-  e.preventDefault();
-  const formData = new FormData();
-  formData.append('message', document.getElementById('message').value);
+const uploadForm = document.getElementById('uploadForm');
+const statusEl = document.getElementById('status');
+const resultEl = document.getElementById('result');
+const qrImageEl = document.getElementById('qrImage');
+const openLinkEl = document.getElementById('openLink');
+const submitBtn = document.getElementById('submitBtn');
+
+const API_BASE = window.location.origin.includes('localhost:3000')
+  ? 'http://localhost:5000'
+  : window.location.origin;
+
+function setStatus(message, isError = false) {
+  statusEl.textContent = message;
+  statusEl.classList.toggle('error', isError);
+}
+
+uploadForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  const message = document.getElementById('message').value.trim();
   const file = document.getElementById('video').files[0];
-  if (file) formData.append('video', file);
 
-  const res = await fetch('http://localhost:5000/api/gifts', {
-    method: 'POST',
-    body: formData
-  });
+  if (!message) {
+    setStatus('Please add a gift message before generating the QR code.', true);
+    return;
+  }
 
-  const data = await res.json();
-  document.getElementById('result').innerHTML =
-    `<p>QR Generated:</p><img src="${data.qr}" width="200"/>`;
+  const formData = new FormData();
+  formData.append('message', message);
+
+  if (file) {
+    formData.append('video', file);
+  }
+
+  submitBtn.disabled = true;
+  setStatus('Creating gift and generating your QR code...');
+  resultEl.classList.add('hidden');
+
+  try {
+    const response = await fetch(`${API_BASE}/api/gifts`, {
+      method: 'POST',
+      body: formData
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error || 'Failed to generate QR code.');
+    }
+
+    qrImageEl.src = data.qr;
+    openLinkEl.href = data.viewUrl;
+    resultEl.classList.remove('hidden');
+    setStatus('Gift created successfully. Save or share your QR code.');
+  } catch (error) {
+    setStatus(error.message || 'Could not create gift right now.', true);
+  } finally {
+    submitBtn.disabled = false;
+  }
 });

--- a/client/js/view.js
+++ b/client/js/view.js
@@ -1,11 +1,44 @@
+const statusEl = document.getElementById('viewerStatus');
+const messageEl = document.getElementById('giftMessage');
+const videoEl = document.getElementById('videoPlayer');
+
 const params = new URLSearchParams(window.location.search);
 const id = params.get('id');
 
-fetch(`http://localhost:5000/api/gifts/${id}`)
-  .then(res => res.json())
-  .then(data => {
-    document.getElementById('giftMessage').innerText = data.message;
-    if (data.videoUrl) {
-      document.getElementById('videoPlayer').src = data.videoUrl;
+const API_BASE = window.location.origin.includes('localhost:3000')
+  ? 'http://localhost:5000'
+  : window.location.origin;
+
+function setStatus(message, isError = false) {
+  statusEl.textContent = message;
+  statusEl.classList.toggle('error', isError);
+}
+
+async function loadGift() {
+  if (!id) {
+    setStatus('Missing gift link. Please scan a valid QR code.', true);
+    return;
+  }
+
+  try {
+    const response = await fetch(`${API_BASE}/api/gifts/${encodeURIComponent(id)}`);
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.error || 'Gift not available.');
     }
-  });
+
+    messageEl.textContent = data.message;
+
+    if (data.videoUrl) {
+      videoEl.src = `${API_BASE}${data.videoUrl}`;
+      videoEl.classList.remove('hidden');
+    }
+
+    setStatus('');
+  } catch (error) {
+    setStatus(error.message || 'Unable to load this gift.', true);
+  }
+}
+
+loadGift();

--- a/client/upload.html
+++ b/client/upload.html
@@ -1,17 +1,37 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-  <title>Upload Gift</title>
-  <link rel="stylesheet" href="css/styles.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Create Gift | Smart QR Gifting</title>
+  <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body>
-  <h2>Upload Your Gift</h2>
-  <form id="uploadForm">
-    <input type="text" id="message" placeholder="Your message" required />
-    <input type="file" id="video" accept="video/*" />
-    <button type="submit">Generate QR</button>
-  </form>
-  <div id="result"></div>
+  <main class="page">
+    <section class="card">
+      <a class="back-link" href="index.html">← Back</a>
+      <h1>Create your gift</h1>
+      <p class="subtle">Add a heartfelt message and an optional video. We'll generate a QR code ready to print or share.</p>
+
+      <form id="uploadForm" class="gift-form" novalidate>
+        <label for="message">Gift message</label>
+        <textarea id="message" maxlength="300" placeholder="Write something memorable..." required></textarea>
+
+        <label for="video">Optional video (MP4, WebM, OGG, MOV · max 30MB)</label>
+        <input type="file" id="video" accept="video/mp4,video/webm,video/ogg,video/quicktime" />
+
+        <button id="submitBtn" type="submit">Generate QR code</button>
+      </form>
+
+      <p id="status" class="status" aria-live="polite"></p>
+
+      <section id="result" class="result hidden" aria-live="polite">
+        <h2>Your gift is ready 🎉</h2>
+        <img id="qrImage" alt="Gift QR code" />
+        <a id="openLink" class="button-link" target="_blank" rel="noopener noreferrer">Open gift page</a>
+      </section>
+    </section>
+  </main>
   <script src="js/upload.js"></script>
 </body>
 </html>

--- a/client/view.html
+++ b/client/view.html
@@ -1,13 +1,21 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-  <title>View Gift</title>
-  <link rel="stylesheet" href="css/styles.css">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Your Gift | Smart QR Gifting</title>
+  <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body>
-  <h2>Your Surprise 🎁</h2>
-  <video id="videoPlayer" controls autoplay style="max-width:100%"></video>
-  <p id="giftMessage"></p>
+  <main class="page viewer-page">
+    <section class="card viewer-card">
+      <h1>Your surprise 🎁</h1>
+      <p id="viewerStatus" class="status" aria-live="polite">Loading your gift...</p>
+
+      <video id="videoPlayer" class="gift-video hidden" controls playsinline preload="metadata"></video>
+      <p id="giftMessage" class="gift-message"></p>
+    </section>
+  </main>
   <script src="js/view.js"></script>
 </body>
 </html>

--- a/server/controllers/giftController.js
+++ b/server/controllers/giftController.js
@@ -1,27 +1,104 @@
-const multer = require('multer');
+const fs = require('fs');
 const path = require('path');
-const QRCode = require('qrcode');
+const multer = require('multer');
 const Gift = require('../models/Gift');
+const { generateQrDataUrl } = require('../utils/qrGenerator');
+
+const uploadsDir = path.resolve(__dirname, '..', '..', 'uploads');
+if (!fs.existsSync(uploadsDir)) {
+  fs.mkdirSync(uploadsDir, { recursive: true });
+}
+
+const VIDEO_MIME_TYPES = ['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
 
 const storage = multer.diskStorage({
-  destination: 'uploads/',
-  filename: (_, file, cb) => cb(null, Date.now() + path.extname(file.originalname))
+  destination: (_req, _file, cb) => cb(null, uploadsDir),
+  filename: (_req, file, cb) => {
+    const safeExt = path.extname(file.originalname).toLowerCase() || '.mp4';
+    cb(null, `${Date.now()}-${Math.round(Math.random() * 1e9)}${safeExt}`);
+  }
 });
-const upload = multer({ storage }).single('video');
 
-exports.createGift = (req, res) => {
-  upload(req, res, async () => {
+const upload = multer({
+  storage,
+  limits: { fileSize: 30 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    if (VIDEO_MIME_TYPES.includes(file.mimetype)) {
+      cb(null, true);
+      return;
+    }
+
+    cb(new Error('Unsupported video format. Please upload MP4, WebM, OGG, or MOV.'));
+  }
+}).single('video');
+
+function runUpload(req, res) {
+  return new Promise((resolve, reject) => {
+    upload(req, res, (err) => {
+      if (!err) {
+        resolve();
+        return;
+      }
+
+      if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+        reject({ status: 400, message: 'Video must be 30MB or smaller.' });
+        return;
+      }
+
+      reject({ status: 400, message: err.message || 'Upload failed.' });
+    });
+  });
+}
+
+function buildPublicBaseUrl(req) {
+  return process.env.PUBLIC_BASE_URL || `${req.protocol}://${req.get('host')}`;
+}
+
+exports.createGift = async (req, res, next) => {
+  try {
+    await runUpload(req, res);
+
+    const message = (req.body.message || '').trim();
+    if (!message) {
+      throw { status: 400, message: 'Message is required.' };
+    }
+
     const gift = await Gift.create({
-      message: req.body.message,
+      message,
       videoUrl: req.file ? `/uploads/${req.file.filename}` : ''
     });
 
-    const qr = await QRCode.toDataURL(`http://localhost:3000/view.html?id=${gift._id}`);
-    res.json({ qr });
-  });
+    const viewUrl = `${buildPublicBaseUrl(req)}/view.html?id=${gift._id}`;
+    const qr = await generateQrDataUrl(viewUrl);
+
+    res.status(201).json({
+      id: gift._id,
+      message: gift.message,
+      videoUrl: gift.videoUrl,
+      viewUrl,
+      qr
+    });
+  } catch (error) {
+    next(error);
+  }
 };
 
-exports.getGift = async (req, res) => {
-  const gift = await Gift.findById(req.params.id);
-  res.json(gift);
+exports.getGift = async (req, res, next) => {
+  try {
+    const gift = await Gift.findById(req.params.id).lean();
+
+    if (!gift) {
+      res.status(404).json({ error: 'Gift not found.' });
+      return;
+    }
+
+    res.json({
+      id: gift._id,
+      message: gift.message,
+      videoUrl: gift.videoUrl,
+      createdAt: gift.createdAt
+    });
+  } catch (error) {
+    next({ status: 400, message: 'Invalid gift ID.' });
+  }
 };

--- a/server/models/Gift.js
+++ b/server/models/Gift.js
@@ -1,8 +1,21 @@
 const mongoose = require('mongoose');
 
-const GiftSchema = new mongoose.Schema({
-  message: String,
-  videoUrl: String
-});
+const GiftSchema = new mongoose.Schema(
+  {
+    message: {
+      type: String,
+      required: [true, 'Message is required'],
+      trim: true,
+      maxlength: [300, 'Message must be 300 characters or less']
+    },
+    videoUrl: {
+      type: String,
+      default: ''
+    }
+  },
+  {
+    timestamps: true
+  }
+);
 
 module.exports = mongoose.model('Gift', GiftSchema);

--- a/server/server.js
+++ b/server/server.js
@@ -1,14 +1,48 @@
+const path = require('path');
 const express = require('express');
 const cors = require('cors');
 const mongoose = require('mongoose');
 const giftRoutes = require('./routes/giftRoutes');
 
 const app = express();
-app.use(cors());
+const PORT = process.env.PORT || 5000;
+const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN || 'http://localhost:3000';
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/smartqr';
+
+app.use(
+  cors({
+    origin: CLIENT_ORIGIN,
+    methods: ['GET', 'POST']
+  })
+);
 app.use(express.json());
-app.use('/uploads', express.static('uploads'));
+app.use('/uploads', express.static(path.resolve(__dirname, '..', 'uploads')));
+
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
 app.use('/api/gifts', giftRoutes);
 
-mongoose.connect('mongodb://127.0.0.1:27017/smartqr');
+app.use((err, _req, res, _next) => {
+  const status = err.status || 500;
+  const message = err.message || 'Unexpected server error';
 
-app.listen(5000, () => console.log('Server running on 5000'));
+  if (status >= 500) {
+    console.error(err);
+  }
+
+  res.status(status).json({ error: message });
+});
+
+mongoose
+  .connect(MONGODB_URI)
+  .then(() => {
+    app.listen(PORT, () => {
+      console.log(`Server running on ${PORT}`);
+    });
+  })
+  .catch((error) => {
+    console.error('Failed to connect to MongoDB', error);
+    process.exit(1);
+  });

--- a/server/utils/qrGenerator.js
+++ b/server/utils/qrGenerator.js
@@ -1,1 +1,15 @@
-// reserved for future enhancements
+const QRCode = require('qrcode');
+
+const DEFAULT_OPTIONS = {
+  width: 320,
+  margin: 1,
+  errorCorrectionLevel: 'M'
+};
+
+async function generateQrDataUrl(url) {
+  return QRCode.toDataURL(url, DEFAULT_OPTIONS);
+}
+
+module.exports = {
+  generateQrDataUrl
+};


### PR DESCRIPTION
### Motivation
- Make the MVP production-ready by hardening the backend upload/QR flow, adding clear errors and startup behavior, and making the frontend mobile-first and resilient. 
- Ensure uploaded video assets are stored and served safely, QR links are generated reliably for mobile scanning, and the viewer displays a robust experience with clear loading/error states.

### Description
- Server: replaced simple startup with a configurable, env-driven boot (`PORT`, `CLIENT_ORIGIN`, `MONGODB_URI`), added `/api/health`, centralized JSON error middleware, and serve uploads from an absolute `uploads` path in `server/server.js`.
- Upload & API: implemented safe upload directory creation, randomized filenames, strict `multer` config with a 30MB limit and MIME whitelist, trimmed/required message validation, dynamic public URL generation (uses `PUBLIC_BASE_URL` or request host), and richer create/get JSON responses in `server/controllers/giftController.js`.
- Data & utils: added schema-level validation and timestamps to the `Gift` model in `server/models/Gift.js`, and factored QR generation into `server/utils/qrGenerator.js` with explicit QR options for mobile reliability.
- Frontend: rebuilt `client/index.html`, `client/upload.html`, `client/view.html` and `client/css/styles.css` for a mobile-first, responsive UI; improved `client/js/upload.js` and `client/js/view.js` with dynamic `API_BASE` detection, clear status states, error handling, QR rendering, and mobile-safe video playback (`playsinline`).

### Testing
- Ran syntax checks with `node --check` for updated server and client JS files, which passed. 
- Captured a mobile-viewport screenshot of `upload.html` using Playwright to validate the responsive upload UI (artifact produced). 
- Attempted to start the server with `npm start` in this environment, but the process could not be verified end-to-end before the environment timeout and a direct `curl` health-check to `127.0.0.1:5000` could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c9d4c667c83299b6ebc9cb8cb6778)