### PR TITLE
Frontend: use Railway production API base and add resilient fetch helper

### DIFF
--- a/client/js/config.js
+++ b/client/js/config.js
@@ -1,0 +1,38 @@
+const API_BASE = "https://smart-qr-gifting-production.up.railway.app";
+const REQUEST_TIMEOUT_MS = 20000;
+
+async function fetchJson(path, options = {}) {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${API_BASE}${path}`, {
+      ...options,
+      signal: controller.signal,
+      headers: {
+        ...(options.headers || {})
+      }
+    });
+
+    let data = {};
+    try {
+      data = await response.json();
+    } catch (parseError) {
+      data = {};
+    }
+
+    if (!response.ok) {
+      throw new Error(data.error || 'Request failed. Please try again.');
+    }
+
+    return data;
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      throw new Error('Request timed out. Please check your connection and try again.');
+    }
+
+    throw error;
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}

--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -5,10 +5,6 @@ const qrImageEl = document.getElementById('qrImage');
 const openLinkEl = document.getElementById('openLink');
 const submitBtn = document.getElementById('submitBtn');
 
-const API_BASE = window.location.origin.includes('localhost:3000')
-  ? 'http://localhost:5000'
-  : window.location.origin;
-
 function setStatus(message, isError = false) {
   statusEl.textContent = message;
   statusEl.classList.toggle('error', isError);
@@ -37,15 +33,10 @@ uploadForm.addEventListener('submit', async (event) => {
   resultEl.classList.add('hidden');
 
   try {
-    const response = await fetch(`${API_BASE}/api/gifts`, {
+    const data = await fetchJson('/api/gifts', {
       method: 'POST',
       body: formData
     });
-
-    const data = await response.json();
-    if (!response.ok) {
-      throw new Error(data.error || 'Failed to generate QR code.');
-    }
 
     qrImageEl.src = data.qr;
     openLinkEl.href = data.viewUrl;

--- a/client/js/view.js
+++ b/client/js/view.js
@@ -5,13 +5,21 @@ const videoEl = document.getElementById('videoPlayer');
 const params = new URLSearchParams(window.location.search);
 const id = params.get('id');
 
-const API_BASE = window.location.origin.includes('localhost:3000')
-  ? 'http://localhost:5000'
-  : window.location.origin;
-
 function setStatus(message, isError = false) {
   statusEl.textContent = message;
   statusEl.classList.toggle('error', isError);
+}
+
+function resolveMediaUrl(videoUrl) {
+  if (!videoUrl) {
+    return '';
+  }
+
+  if (videoUrl.startsWith('http://') || videoUrl.startsWith('https://')) {
+    return videoUrl;
+  }
+
+  return `${API_BASE}${videoUrl}`;
 }
 
 async function loadGift() {
@@ -21,17 +29,12 @@ async function loadGift() {
   }
 
   try {
-    const response = await fetch(`${API_BASE}/api/gifts/${encodeURIComponent(id)}`);
-    const data = await response.json();
-
-    if (!response.ok) {
-      throw new Error(data.error || 'Gift not available.');
-    }
+    const data = await fetchJson(`/api/gifts/${encodeURIComponent(id)}`);
 
     messageEl.textContent = data.message;
 
     if (data.videoUrl) {
-      videoEl.src = `${API_BASE}${data.videoUrl}`;
+      videoEl.src = resolveMediaUrl(data.videoUrl);
       videoEl.classList.remove('hidden');
     }
 

--- a/client/upload.html
+++ b/client/upload.html
@@ -32,6 +32,7 @@
       </section>
     </section>
   </main>
+  <script src="js/config.js"></script>
   <script src="js/upload.js"></script>
 </body>
 </html>

--- a/client/view.html
+++ b/client/view.html
@@ -16,6 +16,7 @@
       <p id="giftMessage" class="gift-message"></p>
     </section>
   </main>
+  <script src="js/config.js"></script>
   <script src="js/view.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Point the static frontend at the live Railway backend so deployed sites (Vercel) communicate with the production API rather than local dev servers.
- Replace ad-hoc origin-based `localhost` switching with a single shared runtime-safe config and a robust fetch helper to improve reliability on mobile/spotty networks.

### Description
- Added a shared config module `client/js/config.js` with `const API_BASE = "https://smart-qr-gifting-production.up.railway.app"` and a `fetchJson` helper that includes request timeout, JSON parse safety, and consistent error messages.
- Updated gift creation flow to use `fetchJson('/api/gifts', ...)` in `client/js/upload.js` and removed the previous `localhost` origin detection logic.
- Updated gift viewer flow in `client/js/view.js` to use `fetchJson('/api/gifts/:id')` and added `resolveMediaUrl` to correctly handle absolute and relative `videoUrl` values for reliable playback.
- Ensured `client/upload.html` and `client/view.html` load `js/config.js` before their page scripts so `API_BASE` and `fetchJson` are available under static hosting.

### Testing
- Ran syntax checks with `node --check` on `client/js/config.js`, `client/js/upload.js`, and `client/js/view.js`, which succeeded.
- Scanned the client source for `localhost`/`127.0.0.1` references using `rg`, confirming no remaining hardcoded local endpoints in the client.
- Attempted a live backend health call to `https://smart-qr-gifting-production.up.railway.app/api/health`, but the execution environment blocked outbound CONNECT (received a 403), so live end-to-end verification from this environment was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca4c4bc788329a1f528093f7c5094)