### PR TITLE
Harden server startup for Railway and add resilient MongoDB handling

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -6,8 +6,19 @@ const giftRoutes = require('./routes/giftRoutes');
 
 const app = express();
 const PORT = process.env.PORT || 5000;
+const HOST = '0.0.0.0';
 const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN || 'http://localhost:3000';
-const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017/smartqr';
+const MONGODB_URI = process.env.MONGODB_URI;
+
+let mongoReady = false;
+
+process.on('unhandledRejection', (reason) => {
+  console.error('[boot] Unhandled promise rejection:', reason);
+});
+
+process.on('uncaughtException', (error) => {
+  console.error('[boot] Uncaught exception:', error);
+});
 
 app.use(
   cors({
@@ -22,6 +33,14 @@ app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
+app.use('/api/gifts', (req, res, next) => {
+  if (!mongoReady) {
+    res.status(503).json({ error: 'Database is not connected yet. Please retry shortly.' });
+    return;
+  }
+
+  next();
+});
 app.use('/api/gifts', giftRoutes);
 
 app.use((err, _req, res, _next) => {
@@ -29,20 +48,47 @@ app.use((err, _req, res, _next) => {
   const message = err.message || 'Unexpected server error';
 
   if (status >= 500) {
-    console.error(err);
+    console.error('[request] Unhandled error:', err);
   }
 
   res.status(status).json({ error: message });
 });
 
-mongoose
-  .connect(MONGODB_URI)
-  .then(() => {
-    app.listen(PORT, () => {
-      console.log(`Server running on ${PORT}`);
+mongoose.connection.on('connected', () => {
+  mongoReady = true;
+  console.log('[mongo] Connected successfully.');
+});
+
+mongoose.connection.on('disconnected', () => {
+  mongoReady = false;
+  console.warn('[mongo] Disconnected.');
+});
+
+mongoose.connection.on('error', (error) => {
+  mongoReady = false;
+  console.error('[mongo] Connection error:', error.message);
+});
+
+async function connectMongoWithRetry() {
+  if (!MONGODB_URI) {
+    console.error('[boot] MONGODB_URI is not set. API will run without database connectivity.');
+    return;
+  }
+
+  try {
+    console.log('[boot] Connecting to MongoDB...');
+    await mongoose.connect(MONGODB_URI, {
+      serverSelectionTimeoutMS: 5000
     });
-  })
-  .catch((error) => {
-    console.error('Failed to connect to MongoDB', error);
-    process.exit(1);
-  });
+  } catch (error) {
+    mongoReady = false;
+    console.error('[mongo] Initial connection failed:', error.message);
+    console.log('[mongo] Retrying MongoDB connection in 5 seconds...');
+    setTimeout(connectMongoWithRetry, 5000);
+  }
+}
+
+app.listen(PORT, HOST, () => {
+  console.log(`[boot] Server listening on ${HOST}:${PORT}`);
+  connectMongoWithRetry();
+});


### PR DESCRIPTION
### Motivation
- Ensure the Express backend responds to Railway health checks immediately and does not crash if MongoDB is temporarily unavailable.
- Use Railway-friendly listen semantics (`process.env.PORT` with `0.0.0.0`) and rely on `process.env.MONGODB_URI` for production DB configuration.

### Description
- No external skill was required for this change (no SKILL.md used) because the fix is a straightforward server runtime/boot adjustment.
- Bind Express to `0.0.0.0` and continue to use `const PORT = process.env.PORT || 5000;` so Railway can route traffic to the process. (`server/server.js`).
- Preserve existing `GET /api/health` that returns `{ status: 'ok' }` so platform health checks succeed even before DB is connected. (`/api/health`).
- Remove local Mongo fallback and use `process.env.MONGODB_URI` exclusively, add `mongoose` lifecycle logging (`connected`, `disconnected`, `error`) and `unhandledRejection`/`uncaughtException` boot logging. (`server/server.js`).
- Start the HTTP server immediately and connect to MongoDB asynchronously with a retry loop so the process does not exit on initial DB failures; add a `mongoReady` guard that returns `503` for `/api/gifts` until the DB is available. (`server/server.js`).
- Leave `package.json` `start` script as `node server/server.js` (Railway-compatible) and do not modify frontend code.

### Testing
- Verified that `GET /api/health` returns JSON by running `node server/server.js` locally and curling `http://127.0.0.1:5000/api/health`, which returned `{ "status": "ok" }` (success).
- Verified graceful behavior when DB is unavailable by curling `http://127.0.0.1:5000/api/gifts/123` while no `MONGODB_URI` is set, which returned `503` and `{ "error": "Database is not connected yet. Please retry shortly." }` instead of crashing the process (success).
- Confirmed server starts and logs boot messages including Mongo connection attempts in `/tmp/smartqr.log` during local runs (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca6e2e1f08329a9f7c4258ab3c896)