### PR TITLE
Railway-safe server startup, Mongo connection handling, CORS and client API base fixes

### DIFF
--- a/client/js/config.js
+++ b/client/js/config.js
@@ -1,4 +1,4 @@
-const API_BASE = "https://smart-qr-gifting-production.up.railway.app";
+const API_BASE = "https://smart-qr-gifting-production.up.railway.app/api";
 const REQUEST_TIMEOUT_MS = 20000;
 
 async function fetchJson(path, options = {}) {

--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -33,7 +33,7 @@ uploadForm.addEventListener('submit', async (event) => {
   resultEl.classList.add('hidden');
 
   try {
-    const data = await fetchJson('/api/gifts', {
+    const data = await fetchJson('/gifts', {
       method: 'POST',
       body: formData
     });

--- a/client/js/view.js
+++ b/client/js/view.js
@@ -19,7 +19,7 @@ function resolveMediaUrl(videoUrl) {
     return videoUrl;
   }
 
-  return `${API_BASE}${videoUrl}`;
+  return `${API_BASE.replace(/\/api$/, '')}${videoUrl}`;
 }
 
 async function loadGift() {
@@ -29,7 +29,7 @@ async function loadGift() {
   }
 
   try {
-    const data = await fetchJson(`/api/gifts/${encodeURIComponent(id)}`);
+    const data = await fetchJson(`/gifts/${encodeURIComponent(id)}`);
 
     messageEl.textContent = data.message;
 

--- a/server/server.js
+++ b/server/server.js
@@ -7,8 +7,7 @@ const giftRoutes = require('./routes/giftRoutes');
 const app = express();
 const PORT = process.env.PORT || 5000;
 const HOST = '0.0.0.0';
-const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN || 'http://localhost:3000';
-const MONGODB_URI = process.env.MONGODB_URI;
+const DEFAULT_VERCEL_ORIGIN = 'https://smart-qr-gifting.vercel.app';
 
 let mongoReady = false;
 
@@ -22,7 +21,21 @@ process.on('uncaughtException', (error) => {
 
 app.use(
   cors({
-    origin: CLIENT_ORIGIN,
+    origin(origin, callback) {
+      const allowedOrigins = [
+        process.env.CLIENT_ORIGIN,
+        process.env.VERCEL_FRONTEND_URL,
+        DEFAULT_VERCEL_ORIGIN,
+        'http://localhost:3000'
+      ].filter(Boolean);
+
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error('Not allowed by CORS'));
+    },
     methods: ['GET', 'POST']
   })
 );
@@ -69,26 +82,25 @@ mongoose.connection.on('error', (error) => {
   console.error('[mongo] Connection error:', error.message);
 });
 
-async function connectMongoWithRetry() {
-  if (!MONGODB_URI) {
-    console.error('[boot] MONGODB_URI is not set. API will run without database connectivity.');
-    return;
+async function startServer() {
+  const mongoUri = process.env.MONGODB_URI;
+
+  if (!mongoUri) {
+    console.warn('Mongo connection failed: MONGODB_URI is not set. Starting API without database connection.');
+  } else {
+    try {
+      await mongoose.connect(mongoUri, {
+        serverSelectionTimeoutMS: 5000
+      });
+      console.log('Mongo connected');
+    } catch (error) {
+      console.error('Mongo connection failed', error.message);
+    }
   }
 
-  try {
-    console.log('[boot] Connecting to MongoDB...');
-    await mongoose.connect(MONGODB_URI, {
-      serverSelectionTimeoutMS: 5000
-    });
-  } catch (error) {
-    mongoReady = false;
-    console.error('[mongo] Initial connection failed:', error.message);
-    console.log('[mongo] Retrying MongoDB connection in 5 seconds...');
-    setTimeout(connectMongoWithRetry, 5000);
-  }
+  app.listen(PORT, HOST, () => {
+    console.log(`[boot] Server listening on ${HOST}:${PORT}`);
+  });
 }
 
-app.listen(PORT, HOST, () => {
-  console.log(`[boot] Server listening on ${HOST}:${PORT}`);
-  connectMongoWithRetry();
-});
+startServer();


### PR DESCRIPTION
### Motivation
- Railway builds were failing with `secret MONGODB_URI not found`; the server must not crash during build or when the env var is absent.  
- Ensure the app only attempts Mongo connectivity at runtime, keep health checks for Railway, and allow the production frontend domain and localhost via CORS.  
- Align client API endpoints to the Railway-hosted `/api` base so uploads and QR views work in production.

### Description
- Refactored backend boot to an async `startServer()` that reads `process.env.MONGODB_URI` at runtime and attempts `mongoose.connect` inside a `try/catch`, logging `Mongo connected` or `Mongo connection failed` and continuing to start the Express server even if the URI is missing (file: `server/server.js`).
- Replaced the static CORS origin with a function that allows `process.env.CLIENT_ORIGIN`, `process.env.VERCEL_FRONTEND_URL`, the default Vercel domain, and `http://localhost:3000` (file: `server/server.js`).
- Preserved the Railway-friendly port binding `const PORT = process.env.PORT || 5000` and the `/api/health` route that returns `{ status: "ok" }` (file: `server/server.js`).
- Updated client API base to `https://smart-qr-gifting-production.up.railway.app/api` and adjusted upload/view calls and media URL resolution so endpoints and uploaded assets resolve correctly in production (files: `client/js/config.js`, `client/js/upload.js`, `client/js/view.js`).
- No changes to existing routes or business logic were made; behavior of `/api/gifts` and QR generation/uploading is preserved.

### Testing
- Ran `node --check server/server.js` to validate server syntax and it succeeded.  
- Ran `node --check client/js/config.js`, `node --check client/js/upload.js`, and `node --check client/js/view.js` and all checks succeeded.  
- No automated unit tests existed in the project; only syntax checks were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca84e57d883298e71114822ea4b79)