### PR TITLE
Harden gift API handling for Railway production reliability

### DIFF
--- a/server/controllers/giftController.js
+++ b/server/controllers/giftController.js
@@ -5,14 +5,24 @@ const Gift = require('../models/Gift');
 const { generateQrDataUrl } = require('../utils/qrGenerator');
 
 const uploadsDir = path.resolve(__dirname, '..', '..', 'uploads');
-if (!fs.existsSync(uploadsDir)) {
-  fs.mkdirSync(uploadsDir, { recursive: true });
+
+function ensureUploadsDir() {
+  if (!fs.existsSync(uploadsDir)) {
+    fs.mkdirSync(uploadsDir, { recursive: true });
+  }
 }
 
 const VIDEO_MIME_TYPES = ['video/mp4', 'video/webm', 'video/ogg', 'video/quicktime'];
 
 const storage = multer.diskStorage({
-  destination: (_req, _file, cb) => cb(null, uploadsDir),
+  destination: (_req, _file, cb) => {
+    try {
+      ensureUploadsDir();
+      cb(null, uploadsDir);
+    } catch (error) {
+      cb(error);
+    }
+  },
   filename: (_req, file, cb) => {
     const safeExt = path.extname(file.originalname).toLowerCase() || '.mp4';
     cb(null, `${Date.now()}-${Math.round(Math.random() * 1e9)}${safeExt}`);
@@ -23,6 +33,11 @@ const upload = multer({
   storage,
   limits: { fileSize: 30 * 1024 * 1024 },
   fileFilter: (_req, file, cb) => {
+    if (!file) {
+      cb(null, true);
+      return;
+    }
+
     if (VIDEO_MIME_TYPES.includes(file.mimetype)) {
       cb(null, true);
       return;
@@ -41,11 +56,11 @@ function runUpload(req, res) {
       }
 
       if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
-        reject({ status: 400, message: 'Video must be 30MB or smaller.' });
+        reject(new Error('Video must be 30MB or smaller.'));
         return;
       }
 
-      reject({ status: 400, message: err.message || 'Upload failed.' });
+      reject(new Error(err.message || 'Upload failed.'));
     });
   });
 }
@@ -54,51 +69,59 @@ function buildPublicBaseUrl(req) {
   return process.env.PUBLIC_BASE_URL || `${req.protocol}://${req.get('host')}`;
 }
 
-exports.createGift = async (req, res, next) => {
+async function createGift(req, res) {
   try {
     await runUpload(req, res);
 
-    const message = (req.body.message || '').trim();
+    const message = typeof req.body.message === 'string' ? req.body.message.trim() : '';
     if (!message) {
-      throw { status: 400, message: 'Message is required.' };
+      throw new Error('Message is required.');
     }
 
-    const gift = await Gift.create({
+    const videoUrl = req.file && req.file.filename ? `/uploads/${req.file.filename}` : '';
+
+    const gift = new Gift({
       message,
-      videoUrl: req.file ? `/uploads/${req.file.filename}` : ''
+      videoUrl
     });
+
+    await gift.save();
 
     const viewUrl = `${buildPublicBaseUrl(req)}/view.html?id=${gift._id}`;
-    const qr = await generateQrDataUrl(viewUrl);
+    const qrCodeUrl = await generateQrDataUrl(viewUrl);
 
-    res.status(201).json({
-      id: gift._id,
-      message: gift.message,
-      videoUrl: gift.videoUrl,
-      viewUrl,
-      qr
+    return res.status(201).json({
+      success: true,
+      qrCodeUrl,
+      giftId: gift._id.toString()
     });
   } catch (error) {
-    next(error);
+    const message = error && error.message ? error.message : 'Unexpected server error';
+    return res.status(500).json({ error: message });
   }
-};
+}
 
-exports.getGift = async (req, res, next) => {
+async function getGift(req, res) {
   try {
     const gift = await Gift.findById(req.params.id).lean();
 
     if (!gift) {
-      res.status(404).json({ error: 'Gift not found.' });
-      return;
+      return res.status(404).json({ error: 'Gift not found.' });
     }
 
-    res.json({
+    return res.json({
       id: gift._id,
       message: gift.message,
       videoUrl: gift.videoUrl,
       createdAt: gift.createdAt
     });
   } catch (error) {
-    next({ status: 400, message: 'Invalid gift ID.' });
+    const message = error && error.message ? error.message : 'Unexpected server error';
+    return res.status(500).json({ error: message });
   }
+}
+
+module.exports = {
+  createGift,
+  getGift
 };

--- a/server/routes/giftRoutes.js
+++ b/server/routes/giftRoutes.js
@@ -2,7 +2,14 @@ const express = require('express');
 const router = express.Router();
 const { createGift, getGift } = require('../controllers/giftController');
 
-router.post('/', createGift);
-router.get('/:id', getGift);
+const asyncRoute = (handler) => (req, res, next) => {
+  Promise.resolve(handler(req, res, next)).catch((error) => {
+    const message = error && error.message ? error.message : 'Unexpected server error';
+    res.status(500).json({ error: message });
+  });
+};
+
+router.post('/', asyncRoute(createGift));
+router.get('/:id', asyncRoute(getGift));
 
 module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const fs = require('fs');
 const express = require('express');
 const cors = require('cors');
 const mongoose = require('mongoose');
@@ -6,9 +7,15 @@ const giftRoutes = require('./routes/giftRoutes');
 
 const app = express();
 const PORT = process.env.PORT || 5000;
-const DEFAULT_VERCEL_ORIGIN = 'https://smart-qr-gifting.vercel.app';
+const uploadsDir = path.resolve(__dirname, '..', 'uploads');
 
 let mongoReady = false;
+
+function ensureUploadsDir() {
+  if (!fs.existsSync(uploadsDir)) {
+    fs.mkdirSync(uploadsDir, { recursive: true });
+  }
+}
 
 process.on('unhandledRejection', (reason) => {
   console.error('[boot] Unhandled promise rejection:', reason);
@@ -18,31 +25,24 @@ process.on('uncaughtException', (error) => {
   console.error('[boot] Uncaught exception:', error);
 });
 
+app.use((req, res, next) => {
+  console.log(`[req] ${req.method} ${req.url}`);
+  next();
+});
+
 app.use(
   cors({
-    origin(origin, callback) {
-      const allowedOrigins = [
-        process.env.CLIENT_ORIGIN,
-        process.env.VERCEL_FRONTEND_URL,
-        DEFAULT_VERCEL_ORIGIN,
-        'http://localhost:3000'
-      ]
-        .filter(Boolean)
-        .map((allowedOrigin) => allowedOrigin.replace(/\/$/, ''));
-      const requestOrigin = origin ? origin.replace(/\/$/, '') : origin;
-
-      if (!requestOrigin || allowedOrigins.includes(requestOrigin)) {
-        callback(null, true);
-        return;
-      }
-
-      callback(new Error('Not allowed by CORS'));
-    },
-    methods: ['GET', 'POST']
+    origin: true,
+    credentials: true,
+    methods: ['GET', 'POST', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization']
   })
 );
 app.use(express.json());
-app.use('/uploads', express.static(path.resolve(__dirname, '..', 'uploads')));
+app.use(express.urlencoded({ extended: true }));
+
+ensureUploadsDir();
+app.use('/uploads', express.static(uploadsDir));
 
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok' });
@@ -59,14 +59,9 @@ app.use('/api/gifts', (req, res, next) => {
 app.use('/api/gifts', giftRoutes);
 
 app.use((err, _req, res, _next) => {
-  const status = err.status || 500;
-  const message = err.message || 'Unexpected server error';
-
-  if (status >= 500) {
-    console.error('[request] Unhandled error:', err);
-  }
-
-  res.status(status).json({ error: message });
+  const message = err && err.message ? err.message : 'Unexpected server error';
+  console.error('[request] Unhandled error:', err);
+  res.status(500).json({ error: message });
 });
 
 mongoose.connection.on('connected', () => {


### PR DESCRIPTION
### Motivation
- Eliminate 502/CORS crashes by preventing unhandled promise rejections and ensuring every error path returns JSON.
- Make multer uploads robust in the Railway environment by ensuring the uploads directory exists at runtime and avoiding crashes when no video is provided.
- Improve CORS and runtime settings to be compatible with proxy/credentialed deployments and Railway (use `process.env.PORT` and bind `0.0.0.0`).

### Description
- Replace CORS with a permissive credentialed config and add request logging plus `express.urlencoded({ extended: true })` before routes in `server/server.js`.
- Ensure uploads directory is created via `path.resolve` + runtime `fs.mkdirSync(..., { recursive: true })` and serve `/uploads` from that resolved path in `server/server.js`.
- Harden global error middleware to always log and return JSON `{ error: message }` with status `500` in `server/server.js`.
- Add an async-safe route wrapper in `server/routes/giftRoutes.js` that converts thrown promise errors into JSON responses.
- Make multer upload flow defensive in `server/controllers/giftController.js` by creating uploads dir in the storage `destination`, accepting absent `file` safely, converting upload failures to `Error` objects, validating `message`, handling optional `video` safely, saving the `Gift` with `videoUrl` when present, generating the QR via `generateQrDataUrl`, and returning the required success payload `{ success: true, qrCodeUrl, giftId }`.

### Testing
- Ran `node --check server/server.js` which completed without syntax errors (passed).
- Ran `node --check server/controllers/giftController.js` which completed without syntax errors (passed).
- Ran `node --check server/routes/giftRoutes.js` which completed without syntax errors (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb0534c7c8329bee93a85f46b5f0f)