### PR TITLE
chore: remove binary icon files while preserving premium UI overhaul

### DIFF
--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -1,311 +1,169 @@
 :root {
   color-scheme: light;
   --primary: #7c3aed;
-  --primary-hover: #6d28d9;
-  --bg: #f8fafc;
-  --bg-soft: #eef2ff;
-  --card: #ffffff;
+  --primary-light: #a78bfa;
+  --bg-dark: #0b0f1a;
+  --bg-light: #f8fafc;
+  --glass: rgba(255, 255, 255, 0.08);
   --text: #0f172a;
   --muted: #64748b;
-  --border: #e2e8f0;
+  --surface: rgba(255, 255, 255, 0.92);
+  --border: rgba(148, 163, 184, 0.28);
   --ring: rgba(124, 58, 237, 0.35);
   --error: #dc2626;
-  --success: #059669;
-  --radius-card: 16px;
-  --radius-control: 12px;
-  --shadow-sm: 0 8px 20px rgba(15, 23, 42, 0.08);
-  --shadow-md: 0 20px 40px rgba(15, 23, 42, 0.12);
-  --shadow-glow: 0 0 0 1px rgba(124, 58, 237, 0.08), 0 14px 30px rgba(124, 58, 237, 0.18);
+  --radius-lg: 22px;
+  --radius-md: 14px;
+  --shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  --gradient: linear-gradient(135deg, #7c3aed 0%, #a78bfa 100%);
+  --space-1: 0.5rem;
+  --space-2: 0.75rem;
+  --space-3: 1rem;
+  --space-4: 1.5rem;
+  --space-5: 2rem;
 }
 
 :root[data-theme='dark'] {
   color-scheme: dark;
-  --bg: #020617;
-  --bg-soft: #0b1123;
-  --card: #0f172a;
   --text: #e2e8f0;
   --muted: #94a3b8;
-  --border: #1e293b;
-  --ring: rgba(124, 58, 237, 0.5);
-  --shadow-sm: 0 8px 20px rgba(2, 6, 23, 0.5);
-  --shadow-md: 0 18px 38px rgba(2, 6, 23, 0.6);
+  --surface: rgba(15, 23, 42, 0.82);
+  --border: rgba(148, 163, 184, 0.2);
+  --shadow: 0 20px 50px rgba(2, 6, 23, 0.5);
 }
 
 * { box-sizing: border-box; }
-
-html,
-body {
-  margin: 0;
-  min-height: 100%;
-}
-
+html, body { margin: 0; min-height: 100%; overflow-x: hidden; }
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background:
-    radial-gradient(circle at 10% -10%, rgba(124, 58, 237, 0.15), transparent 45%),
-    radial-gradient(circle at 100% 0%, rgba(99, 102, 241, 0.12), transparent 42%),
-    var(--bg);
   color: var(--text);
-  transition: background-color 220ms ease, color 220ms ease;
+  background:
+    radial-gradient(circle at 10% -10%, rgba(124, 58, 237, 0.2), transparent 40%),
+    radial-gradient(circle at 110% 0%, rgba(167, 139, 250, 0.2), transparent 45%),
+    var(--bg-light);
+  transition: background-color 240ms ease, color 240ms ease;
 }
+:root[data-theme='dark'] body { background-color: var(--bg-dark); }
 
-.page {
-  min-height: 100vh;
+.page { min-height: 100vh; padding: max(1rem, env(safe-area-inset-top)) 0 max(5rem, env(safe-area-inset-bottom)); animation: fadeIn 280ms ease; }
+.page-home { padding-bottom: max(7rem, env(safe-area-inset-bottom)); }
+.container { width: min(1100px, calc(100% - 1.5rem)); margin: 0 auto; }
+
+.glass { background: color-mix(in srgb, var(--surface) 84%, transparent); border: 1px solid var(--border); backdrop-filter: blur(14px); }
+.site-header, .topbar {
   display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 20px 14px;
-  animation: fadeIn 220ms ease;
-}
-
-.container {
-  width: min(100%, 980px);
-  margin: 0 auto;
-}
-
-.topbar {
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 10px;
-}
-
-.theme-toggle {
-  border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--card) 85%, transparent);
-  color: var(--text);
+  justify-content: space-between;
+  margin: 0 auto 1.1rem;
+  padding: 0.7rem;
   border-radius: 999px;
-  padding: 10px 14px;
-  font: inherit;
-  font-size: 0.86rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 200ms ease, box-shadow 200ms ease, border-color 200ms ease;
+}
+.logo { color: var(--text); text-decoration: none; font-weight: 700; padding: 0.4rem 0.8rem; }
+.header-actions { display: flex; align-items: center; gap: 0.5rem; }
+
+.control-chip {
+  border: 1px solid var(--border); background: transparent; color: var(--text); border-radius: 999px;
+  padding: 0.5rem 0.75rem; font: inherit; font-size: 0.82rem; font-weight: 600; cursor: pointer;
 }
 
-.theme-toggle:hover { transform: translateY(-1px); border-color: var(--primary); box-shadow: var(--shadow-sm); }
+.hero { display: grid; gap: var(--space-4); padding: 2rem 0 1rem; }
+.hero-copy h1 { font-size: clamp(2rem, 6vw, 3.7rem); line-height: 1.05; letter-spacing: -0.03em; margin: 0 0 0.7rem; }
+.eyebrow { margin: 0 0 0.7rem; color: var(--primary); font-weight: 700; }
+.subtle { color: var(--muted); line-height: 1.65; }
+.hero-card { border-radius: var(--radius-lg); padding: var(--space-4); }
+.hero-cta-row { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-3); }
+
+.section { margin-top: var(--space-5); }
+.section h2 { margin: 0 0 var(--space-3); font-size: clamp(1.35rem, 3vw, 2rem); }
+.grid { display: grid; gap: var(--space-3); }
+.three-up { grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); }
+.four-up { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+.feature-card, .use-card { border-radius: var(--radius-md); padding: var(--space-3); transition: transform 180ms ease, box-shadow 180ms ease; }
+.feature-card:hover, .use-card:hover, .card:hover { transform: translateY(-4px); box-shadow: 0 10px 30px rgba(124, 58, 237, 0.2); }
+
+.chips { display: flex; gap: 0.6rem; flex-wrap: wrap; }
+.chip { background: var(--glass); border: 1px solid var(--border); border-radius: 999px; padding: 0.45rem 0.75rem; font-weight: 600; }
+.cta-banner { margin-top: 2.5rem; padding: 1.8rem; border-radius: var(--radius-lg); text-align: center; }
+.site-footer { display: flex; justify-content: space-between; gap: 0.8rem; flex-wrap: wrap; margin: 2rem auto; color: var(--muted); }
 
 .card {
-  width: min(100%, 620px);
-  margin-inline: auto;
-  background: color-mix(in srgb, var(--card) 90%, transparent);
-  border-radius: var(--radius-card);
-  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
-  padding: 28px;
-  box-shadow: var(--shadow-md);
-  backdrop-filter: blur(9px);
-  transition: border-color 220ms ease, box-shadow 220ms ease, transform 220ms ease;
+  max-width: 700px; margin: 0 auto; border-radius: var(--radius-lg); padding: var(--space-4);
+  background: color-mix(in srgb, var(--surface) 92%, transparent); border: 1px solid var(--border); box-shadow: var(--shadow);
+}
+h1, h2, h3 { margin: 0 0 0.4rem; }
+.gift-form { display: grid; gap: 0.7rem; margin-top: var(--space-3); }
+label { font-weight: 600; font-size: 0.94rem; }
+textarea, input[type='file'] {
+  width: 100%; border: 1px solid var(--border); border-radius: 12px; padding: 0.8rem; font: inherit; color: var(--text);
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+}
+textarea { min-height: 120px; resize: vertical; }
+
+button, .button-link {
+  display: inline-flex; justify-content: center; align-items: center; gap: 0.45rem;
+  border: 0; border-radius: 12px; padding: 0.8rem 1rem; font: inherit; font-weight: 700; cursor: pointer;
+  background: var(--gradient); color: #fff; text-decoration: none; transition: transform 160ms ease, box-shadow 160ms ease;
+}
+.button-secondary { background: transparent; border: 1px solid var(--border); color: var(--text); }
+button:hover, .button-link:hover { transform: translateY(-2px); box-shadow: 0 12px 28px rgba(124, 58, 237, 0.28); }
+button:focus-visible, .button-link:focus-visible, textarea:focus-visible, input:focus-visible, .control-chip:focus-visible, .upload-tab:focus-visible, .back-link:focus-visible {
+  outline: none; box-shadow: 0 0 0 3px var(--ring);
 }
 
-.card:hover {
-  box-shadow: var(--shadow-glow);
+.back-link { color: var(--muted); text-decoration: none; font-weight: 600; margin-right: auto; }
+.upload-tabs { display: flex; flex-wrap: wrap; gap: 0.45rem; margin: 1rem 0; }
+.upload-tab { background: transparent; color: var(--text); border: 1px solid var(--border); border-radius: 999px; padding: 0.4rem 0.8rem; }
+.upload-tab.active { background: var(--gradient); color: #fff; border-color: transparent; }
+
+.empty-state { border: 1px dashed var(--border); border-radius: 12px; padding: 0.8rem; color: var(--muted); margin-bottom: 0.8rem; }
+.progress-wrap { display: grid; gap: 0.3rem; }
+.progress-bar { height: 8px; background: rgba(148, 163, 184, 0.24); border-radius: 999px; overflow: hidden; }
+.progress-bar span { display: block; height: 100%; width: 0; background: var(--gradient); transition: width 160ms ease; }
+.status { min-height: 1.4rem; margin: 0.9rem 0 0; color: var(--muted); }
+.status.error { color: var(--error); }
+.status.loading::after { content: ' ...'; animation: dots 1s steps(4) infinite; }
+
+.result { margin-top: var(--space-3); border: 1px dashed var(--border); border-radius: var(--radius-md); padding: var(--space-3); text-align: center; opacity: 0; transform: translateY(10px); }
+.result img { width: min(100%, 250px); border-radius: 12px; border: 1px solid var(--border); }
+.result.success { animation: revealUp 280ms ease forwards; }
+.action-row { display: flex; flex-wrap: wrap; gap: 0.45rem; justify-content: center; }
+
+.success-burst::before {
+  content: '✨'; display: block; font-size: 2rem; opacity: 0; transform: translateY(8px) scale(0.8);
+}
+.success-burst.run::before { animation: burst 450ms ease; }
+
+.gift-message { margin-top: 16px; font-size: 1.05rem; text-align: center; white-space: pre-wrap; }
+.gift-video { margin-top: 10px; width: 100%; max-height: 52vh; border-radius: 12px; border: 1px solid var(--border); background: #000; }
+
+.mobile-sticky-cta {
+  position: fixed; left: 0; right: 0; bottom: 0; padding: 0.75rem;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  border-top: 1px solid var(--border);
 }
 
-.hero-card {
-  text-align: center;
-  padding: 36px 28px;
+.toast-region { position: fixed; right: 1rem; bottom: calc(1rem + env(safe-area-inset-bottom)); display: grid; gap: 0.5rem; z-index: 40; }
+.toast {
+  background: color-mix(in srgb, var(--surface) 94%, transparent); border: 1px solid var(--border); color: var(--text);
+  border-radius: 10px; padding: 0.6rem 0.8rem; box-shadow: var(--shadow); opacity: 0; transform: translateY(10px); transition: 220ms ease;
 }
+.toast.show { opacity: 1; transform: translateY(0); }
 
-h1,
-h2 { margin: 0 0 10px; line-height: 1.2; }
-
-h1 { font-size: clamp(1.6rem, 4.8vw, 2.35rem); letter-spacing: -0.02em; }
-h2 { font-size: clamp(1.15rem, 3.2vw, 1.5rem); }
-
-.subtle,
-.status {
-  color: var(--muted);
-}
-
-.subtle { margin: 0 0 16px; line-height: 1.6; }
-
-.gift-form {
-  display: grid;
-  gap: 12px;
-  margin-top: 20px;
-  opacity: 0;
-  transform: translateY(6px);
-  animation: formIn 260ms ease forwards;
-}
-
-label {
-  text-align: left;
-  font-weight: 600;
-  font-size: 0.92rem;
-}
-
-textarea,
-input[type='file'] {
-  width: 100%;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-control);
-  padding: 12px 14px;
-  font: inherit;
-  color: var(--text);
-  background: color-mix(in srgb, var(--card) 88%, transparent);
-  transition: border-color 200ms ease, box-shadow 200ms ease;
-}
-
-textarea {
-  min-height: 120px;
-  resize: vertical;
-}
-
-input[type='file'] { cursor: pointer; }
-
-textarea:focus,
-input[type='file']:focus,
-button:focus,
-.button-link:focus,
-.theme-toggle:focus,
-.back-link:focus {
-  outline: none;
-  border-color: var(--primary);
-  box-shadow: 0 0 0 3px var(--ring);
-}
-
-button,
-.button-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  border: 0;
-  border-radius: var(--radius-control);
-  padding: 13px 18px;
-  background: var(--primary);
-  color: #fff;
-  font-weight: 700;
-  text-decoration: none;
-  cursor: pointer;
-  transition: transform 200ms ease, box-shadow 200ms ease, background-color 200ms ease;
-}
-
-button:hover,
-.button-link:hover {
-  background: var(--primary-hover);
-  transform: translateY(-2px);
-  box-shadow: 0 12px 24px rgba(109, 40, 217, 0.28);
-}
-
-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.85;
-}
-
-.cta-animated { animation: pulseOnce 260ms ease; }
-
-.status {
-  margin: 16px 0 0;
-  min-height: 22px;
-  font-size: 0.96rem;
-}
-
-.status.loading::after {
-  content: ' ...';
-  animation: dots 700ms steps(4, end) infinite;
-}
-
-.error { color: var(--error); }
-
-.result {
-  margin-top: 20px;
-  display: grid;
-  gap: 12px;
-  justify-items: center;
-  border: 1px dashed var(--border);
-  border-radius: var(--radius-card);
-  padding: 18px;
-  background: color-mix(in srgb, var(--card) 90%, transparent);
-  transform: translateY(8px);
-  opacity: 0;
-}
-
-.result.success {
-  animation: revealUp 280ms ease forwards;
-}
-
-.result img {
-  width: min(100%, 280px);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  box-shadow: var(--shadow-sm);
-  opacity: 0;
-  transform: scale(0.95);
-}
-
-.result.success img {
-  animation: popIn 220ms ease forwards;
-  animation-delay: 80ms;
-}
-
-.gift-message {
-  margin-top: 16px;
-  font-size: 1.05rem;
-  text-align: center;
-  white-space: pre-wrap;
-}
-
-.gift-video {
-  margin-top: 10px;
-  width: 100%;
-  max-height: 52vh;
-  border-radius: 12px;
-  border: 1px solid var(--border);
-  background: #000;
-}
-
-.back-link {
-  display: inline-block;
-  margin-bottom: 12px;
-  color: var(--muted);
-  text-decoration: none;
-  font-weight: 600;
-}
-
+.reveal { opacity: 0; transform: translateY(18px); transition: 380ms ease; }
+.reveal.visible { opacity: 1; transform: translateY(0); }
+.spinner { width: 16px; height: 16px; border: 2px solid rgba(255,255,255,.5); border-top-color: #fff; border-radius: 50%; animation: spin .8s linear infinite; }
+.sr-only { position: absolute; width: 1px; height: 1px; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
 .hidden { display: none !important; }
 
-.spinner {
-  width: 16px;
-  height: 16px;
-  border: 2px solid rgba(255, 255, 255, 0.45);
-  border-top-color: #fff;
-  border-radius: 50%;
-  animation: spin 700ms linear infinite;
-}
-
-.empty-state {
-  border: 1px dashed var(--border);
-  color: var(--muted);
-  border-radius: 12px;
-  padding: 12px;
-}
-
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
-@keyframes formIn { to { opacity: 1; transform: translateY(0); } }
 @keyframes revealUp { to { opacity: 1; transform: translateY(0); } }
-@keyframes popIn { to { opacity: 1; transform: scale(1); } }
 @keyframes spin { to { transform: rotate(360deg); } }
-@keyframes pulseOnce {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.02); }
-  100% { transform: scale(1); }
-}
-@keyframes dots {
-  0% { content: ' .'; }
-  33% { content: ' ..'; }
-  66% { content: ' ...'; }
-  100% { content: ' ....'; }
-}
-
-@media (max-width: 767px) {
-  .page { padding: 16px 12px; }
-  .card,
-  .hero-card { padding: 20px; }
-  button,
-  .button-link { width: 100%; }
-}
+@keyframes dots { 0% { content: ' .'; } 33% { content: ' ..'; } 66% { content: ' ...'; } 100% { content: ' ....'; } }
+@keyframes burst { 0% { opacity: 0; transform: translateY(8px) scale(.7); } 50% { opacity: 1; transform: translateY(0) scale(1.2); } 100% { opacity: 0; transform: translateY(-5px) scale(1); } }
 
 @media (min-width: 768px) {
-  .topbar { margin-bottom: 14px; }
+  .hero { grid-template-columns: 1.35fr 1fr; align-items: center; }
+  .mobile-sticky-cta { display: none; }
+}
+@media (max-width: 767px) {
+  button, .button-link { width: 100%; }
 }

--- a/client/index.html
+++ b/client/index.html
@@ -2,66 +2,96 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="theme-color" content="#7C3AED" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="SmartQR" />
   <title>Smart QR Gifting</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="apple-touch-icon" href="/icons/icon-192.svg" />
   <link rel="manifest" href="/manifest.json" />
   <link rel="stylesheet" href="css/styles.css" />
 </head>
 <body>
-  <main class="page">
-    <div class="container">
-      <div class="topbar">
-        <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode">🌙 Dark</button>
+  <main class="page page-home">
+    <header class="site-header container glass">
+      <a class="logo" href="index.html" aria-label="Smart QR Gifting Home">🎁 SmartQR</a>
+      <div class="header-actions">
+        <label class="sr-only" for="languageSwitcher">Language</label>
+        <select id="languageSwitcher" class="control-chip" aria-label="Language switcher"></select>
+        <button id="themeToggle" class="control-chip" type="button" aria-label="Toggle dark mode"></button>
       </div>
+    </header>
 
-      <section class="card hero-card">
-        <h1>Smart QR Gifting</h1>
-        <p class="subtle">Create a personalized gift page, attach a video, and share instantly with a scan.</p>
-        <a href="upload.html" class="button-link cta-animated">Create a gift</a>
-      </section>
+    <section class="hero container">
+      <div class="hero-copy reveal">
+        <p class="eyebrow" data-i18n="hero.eyebrow"></p>
+        <h1 data-i18n="hero.title"></h1>
+        <p class="subtle" data-i18n="hero.subtitle"></p>
+        <div class="hero-cta-row">
+          <a href="upload.html" class="button-link" data-i18n="hero.primaryCta"></a>
+          <button id="installBtn" class="button-link button-secondary hidden" type="button" data-i18n="hero.install"></button>
+        </div>
+      </div>
+      <aside class="hero-card glass reveal" aria-label="Product preview">
+        <h2 data-i18n="hero.storyTitle"></h2>
+        <p data-i18n="hero.storyBody"></p>
+      </aside>
+    </section>
+
+    <section class="section container reveal" aria-labelledby="howItWorksHeading">
+      <h2 id="howItWorksHeading" data-i18n="how.title"></h2>
+      <div class="grid three-up">
+        <article class="feature-card glass"><h3 data-i18n="how.step1Title"></h3><p data-i18n="how.step1Body"></p></article>
+        <article class="feature-card glass"><h3 data-i18n="how.step2Title"></h3><p data-i18n="how.step2Body"></p></article>
+        <article class="feature-card glass"><h3 data-i18n="how.step3Title"></h3><p data-i18n="how.step3Body"></p></article>
+      </div>
+    </section>
+
+    <section class="section container reveal" aria-labelledby="formatsHeading">
+      <h2 id="formatsHeading" data-i18n="formats.title"></h2>
+      <div class="chips">
+        <span class="chip" data-i18n="formats.text"></span>
+        <span class="chip" data-i18n="formats.video"></span>
+        <span class="chip" data-i18n="formats.audio"></span>
+        <span class="chip" data-i18n="formats.images"></span>
+        <span class="chip" data-i18n="formats.gif"></span>
+      </div>
+    </section>
+
+    <section class="section container reveal" aria-labelledby="useCasesHeading">
+      <h2 id="useCasesHeading" data-i18n="useCases.title"></h2>
+      <div class="grid four-up">
+        <article class="use-card glass"><h3 data-i18n="useCases.birthdays"></h3></article>
+        <article class="use-card glass"><h3 data-i18n="useCases.corporate"></h3></article>
+        <article class="use-card glass"><h3 data-i18n="useCases.weddings"></h3></article>
+        <article class="use-card glass"><h3 data-i18n="useCases.surprises"></h3></article>
+      </div>
+    </section>
+
+    <section class="section container cta-banner glass reveal">
+      <h2 data-i18n="cta.title"></h2>
+      <p class="subtle" data-i18n="cta.body"></p>
+      <a href="upload.html" class="button-link" data-i18n="cta.button"></a>
+    </section>
+
+    <footer class="site-footer container">
+      <p>© <span id="year"></span> Smart QR Gifting</p>
+      <p data-i18n="footer.tagline"></p>
+    </footer>
+
+    <div class="mobile-sticky-cta">
+      <a href="upload.html" class="button-link" data-i18n="hero.primaryCta"></a>
     </div>
   </main>
 
+  <script src="js/i18n.js"></script>
+  <script src="js/app-shell.js"></script>
   <script>
-    (function () {
-      const root = document.documentElement;
-      const toggle = document.getElementById('themeToggle');
-      const storageKey = 'smartqr-theme';
-      const media = window.matchMedia('(prefers-color-scheme: dark)');
-
-      function applyTheme(theme) {
-        root.setAttribute('data-theme', theme);
-        toggle.textContent = theme === 'dark' ? '☀️ Light' : '🌙 Dark';
-      }
-
-      const saved = localStorage.getItem(storageKey);
-      applyTheme(saved || (media.matches ? 'dark' : 'light'));
-
-      toggle.addEventListener('click', function () {
-        const current = root.getAttribute('data-theme') || 'light';
-        const next = current === 'dark' ? 'light' : 'dark';
-        localStorage.setItem(storageKey, next);
-        applyTheme(next);
-      });
-
-      media.addEventListener('change', function (event) {
-        if (!localStorage.getItem(storageKey)) {
-          applyTheme(event.matches ? 'dark' : 'light');
-        }
-      });
-
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', function () {
-          navigator.serviceWorker.register('/service-worker.js').catch(function (error) {
-            console.warn('Service worker registration failed:', error);
-          });
-        });
-      }
-    })();
+    document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 </body>
 </html>

--- a/client/js/app-shell.js
+++ b/client/js/app-shell.js
@@ -1,0 +1,107 @@
+(function () {
+  const root = document.documentElement;
+  const storageKey = 'smartqr-theme';
+  const media = window.matchMedia('(prefers-color-scheme: dark)');
+  let deferredPrompt;
+
+  function showToast(message) {
+    const region = document.getElementById('toastRegion');
+    if (!region) return;
+    const toast = document.createElement('div');
+    toast.className = 'toast';
+    toast.textContent = message;
+    region.appendChild(toast);
+    requestAnimationFrame(() => toast.classList.add('show'));
+    window.setTimeout(() => {
+      toast.classList.remove('show');
+      window.setTimeout(() => toast.remove(), 220);
+    }, 2200);
+  }
+
+  function applyTheme(theme) {
+    root.setAttribute('data-theme', theme);
+    const toggle = document.getElementById('themeToggle');
+    if (toggle) {
+      toggle.textContent = theme === 'dark' ? '☀️ Light' : '🌙 Dark';
+    }
+  }
+
+  function initTheme() {
+    const saved = localStorage.getItem(storageKey);
+    applyTheme(saved || (media.matches ? 'dark' : 'light'));
+
+    const toggle = document.getElementById('themeToggle');
+    if (toggle) {
+      toggle.addEventListener('click', function () {
+        const current = root.getAttribute('data-theme') || 'light';
+        const next = current === 'dark' ? 'light' : 'dark';
+        localStorage.setItem(storageKey, next);
+        applyTheme(next);
+      });
+    }
+
+    media.addEventListener('change', function (event) {
+      if (!localStorage.getItem(storageKey)) {
+        applyTheme(event.matches ? 'dark' : 'light');
+      }
+    });
+  }
+
+  function initInstallPrompt() {
+    const installBtn = document.getElementById('installBtn');
+    window.addEventListener('beforeinstallprompt', (event) => {
+      event.preventDefault();
+      deferredPrompt = event;
+      if (installBtn) {
+        installBtn.classList.remove('hidden');
+      }
+    });
+
+    if (installBtn) {
+      installBtn.addEventListener('click', async () => {
+        if (!deferredPrompt) return;
+        deferredPrompt.prompt();
+        await deferredPrompt.userChoice;
+        deferredPrompt = null;
+        installBtn.classList.add('hidden');
+      });
+    }
+  }
+
+  function initObservers() {
+    const revealEls = document.querySelectorAll('.reveal');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.2 });
+    revealEls.forEach((el) => observer.observe(el));
+  }
+
+  function registerSW() {
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function () {
+        navigator.serviceWorker.register('/service-worker.js').catch(function (error) {
+          console.warn('Service worker registration failed:', error);
+        });
+      });
+    }
+  }
+
+  function initI18n() {
+    if (!window.smartQRI18n) return;
+    window.smartQRI18n.mountSwitcher();
+    window.smartQRI18n.renderText();
+  }
+
+  initTheme();
+  initInstallPrompt();
+  initObservers();
+  initI18n();
+  registerSW();
+
+  window.smartQRUI = { showToast };
+})();

--- a/client/js/i18n.js
+++ b/client/js/i18n.js
@@ -1,0 +1,113 @@
+(function () {
+  const dictionaries = {
+    en: {
+      'hero.eyebrow': 'Turn moments into unforgettable surprises',
+      'hero.title': 'Create beautiful QR-powered gifts in minutes',
+      'hero.subtitle': 'Craft a personalized page with message, media, and a ready-to-share QR code.',
+      'hero.primaryCta': 'Create a Gift',
+      'hero.install': 'Install App',
+      'hero.storyTitle': 'Why teams and families love SmartQR',
+      'hero.storyBody': 'From birthdays to brand activations, SmartQR helps you deliver meaning through a simple scan.',
+      'how.title': 'How it works',
+      'how.step1Title': '1. Personalize',
+      'how.step1Body': 'Write your message and choose media for the perfect delivery.',
+      'how.step2Title': '2. Generate',
+      'how.step2Body': 'Instantly get a unique QR code linked to your gift page.',
+      'how.step3Title': '3. Delight',
+      'how.step3Body': 'Print, share, or attach your QR and reveal the surprise.',
+      'formats.title': 'Supported gift formats',
+      'formats.text': 'Text',
+      'formats.video': 'Video',
+      'formats.audio': 'Audio',
+      'formats.images': 'Images',
+      'formats.gif': 'GIFs',
+      'useCases.title': 'Built for every occasion',
+      'useCases.birthdays': 'Birthdays',
+      'useCases.corporate': 'Corporate gifting',
+      'useCases.weddings': 'Weddings',
+      'useCases.surprises': 'Surprises',
+      'cta.title': 'Ready to create your next unforgettable gift?',
+      'cta.body': 'Start free and share your first QR gift in less than a minute.',
+      'cta.button': 'Start Creating',
+      'footer.tagline': 'Premium gifting experiences, one scan away.',
+      'upload.title': 'Create your premium gift',
+      'upload.subtitle': 'Keep your existing flow, now with a future-ready media experience.',
+      'upload.tabs.text': 'Text',
+      'upload.tabs.video': 'Video',
+      'upload.tabs.audio': 'Audio',
+      'upload.tabs.image': 'Image',
+      'upload.tabs.gif': 'GIF',
+      'upload.futureHint': 'Video upload is live today. Audio/Image/GIF tabs are UI-ready for upcoming releases.',
+      'upload.messageLabel': 'Gift message',
+      'upload.messagePlaceholder': 'Write something memorable...',
+      'upload.videoLabel': 'Optional video (MP4, WebM, OGG, MOV · max 30MB)',
+      'upload.submit': 'Generate QR code',
+      'upload.resultTitle': 'Your gift is ready 🎉',
+      'upload.openGift': 'Open gift page',
+      'upload.copyLink': 'Copy Link',
+      'upload.share': 'Share',
+      'upload.downloadQr': 'Download QR',
+      'upload.statusLoading': 'Creating gift and generating your QR code',
+      'upload.statusSuccess': 'Gift created successfully. Save or share your QR code.',
+      'upload.statusMissingMessage': 'Please add a gift message before generating the QR code.',
+      'upload.statusFailed': 'Could not create gift right now.'
+    },
+    es: {
+      'hero.eyebrow': 'Convierte momentos en sorpresas inolvidables',
+      'hero.title': 'Crea regalos con QR en minutos',
+      'hero.subtitle': 'Diseña una página personalizada con mensaje, media y QR listo para compartir.',
+      'hero.primaryCta': 'Crear regalo',
+      'hero.install': 'Instalar app',
+      'hero.storyTitle': 'Por qué aman SmartQR',
+      'hero.storyBody': 'Desde cumpleaños hasta activaciones de marca, SmartQR entrega emoción con un escaneo.'
+    }
+  };
+
+  const languages = [{ code: 'en', label: 'English' }, { code: 'es', label: 'Español' }];
+  const storageKey = 'smartqr-lang';
+  const defaultLanguage = 'en';
+
+  function getCurrentLanguage() {
+    const saved = localStorage.getItem(storageKey);
+    if (saved && dictionaries[saved]) return saved;
+    const browser = (navigator.language || '').slice(0, 2);
+    return dictionaries[browser] ? browser : defaultLanguage;
+  }
+
+  function t(key) {
+    const lang = getCurrentLanguage();
+    return dictionaries[lang][key] || dictionaries.en[key] || key;
+  }
+
+  function renderText() {
+    document.documentElement.lang = getCurrentLanguage();
+    document.querySelectorAll('[data-i18n]').forEach((el) => {
+      el.textContent = t(el.getAttribute('data-i18n'));
+    });
+    document.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
+      el.setAttribute('placeholder', t(el.getAttribute('data-i18n-placeholder')));
+    });
+  }
+
+  function mountSwitcher() {
+    const switcher = document.getElementById('languageSwitcher');
+    if (!switcher) return;
+
+    switcher.innerHTML = '';
+    languages.forEach((lang) => {
+      const option = document.createElement('option');
+      option.value = lang.code;
+      option.textContent = lang.label;
+      switcher.append(option);
+    });
+
+    switcher.value = getCurrentLanguage();
+    switcher.addEventListener('change', (event) => {
+      localStorage.setItem(storageKey, event.target.value);
+      renderText();
+      document.dispatchEvent(new CustomEvent('smartqr:languagechange'));
+    });
+  }
+
+  window.smartQRI18n = { t, renderText, mountSwitcher };
+})();

--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -4,8 +4,22 @@ const resultEl = document.getElementById('result');
 const qrImageEl = document.getElementById('qrImage');
 const openLinkEl = document.getElementById('openLink');
 const submitBtn = document.getElementById('submitBtn');
+const copyLinkBtn = document.getElementById('copyLinkBtn');
+const shareBtn = document.getElementById('shareBtn');
+const downloadQrBtn = document.getElementById('downloadQrBtn');
+const progressWrap = document.getElementById('uploadProgressWrap');
+const progressBar = document.getElementById('uploadProgressBar');
+const progressText = document.getElementById('uploadProgressText');
+const successConfetti = document.getElementById('successConfetti');
+const tabs = document.querySelectorAll('.upload-tab');
+const futureHint = document.getElementById('futureUploaderHint');
 
-const defaultBtnLabel = 'Generate QR code';
+let latestGiftUrl = '';
+let latestQrDataUrl = '';
+
+function t(key) {
+  return window.smartQRI18n ? window.smartQRI18n.t(key) : key;
+}
 
 function setStatus(message, isError = false, isLoading = false) {
   statusEl.textContent = message;
@@ -15,11 +29,66 @@ function setStatus(message, isError = false, isLoading = false) {
 
 function setLoadingState(isLoading) {
   submitBtn.disabled = isLoading;
-  if (isLoading) {
-    submitBtn.innerHTML = '<span class="spinner" aria-hidden="true"></span>Generating...';
-  } else {
-    submitBtn.textContent = defaultBtnLabel;
-  }
+  submitBtn.innerHTML = isLoading
+    ? '<span class="spinner" aria-hidden="true"></span>Generating...'
+    : t('upload.submit');
+  progressWrap.classList.toggle('hidden', !isLoading);
+}
+
+function setProgress(percent) {
+  progressBar.style.width = `${Math.max(5, percent)}%`;
+  progressText.textContent = `${Math.round(percent)}%`;
+}
+
+function createGift(formData) {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', `${API_BASE}/api/gifts`);
+    xhr.responseType = 'json';
+
+    xhr.upload.addEventListener('progress', (event) => {
+      if (!event.lengthComputable) return;
+      setProgress((event.loaded / event.total) * 100);
+    });
+
+    xhr.onload = function () {
+      const data = xhr.response || {};
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve(data);
+      } else {
+        reject(new Error(data.error || t('upload.statusFailed')));
+      }
+    };
+
+    xhr.onerror = function () {
+      reject(new Error(t('upload.statusFailed')));
+    };
+
+    xhr.send(formData);
+  });
+}
+
+function launchSuccessBurst() {
+  successConfetti.classList.remove('run');
+  void successConfetti.offsetWidth;
+  successConfetti.classList.add('run');
+}
+
+function initTabs() {
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', () => {
+      tabs.forEach((item) => {
+        item.classList.remove('active');
+        item.setAttribute('aria-selected', 'false');
+      });
+      tab.classList.add('active');
+      tab.setAttribute('aria-selected', 'true');
+
+      const isVideo = tab.dataset.tab === 'video' || tab.dataset.tab === 'text';
+      futureHint.classList.toggle('hidden', isVideo);
+      document.getElementById('video').disabled = tab.dataset.tab !== 'video' && tab.dataset.tab !== 'text';
+    });
+  });
 }
 
 uploadForm.addEventListener('submit', async (event) => {
@@ -29,7 +98,7 @@ uploadForm.addEventListener('submit', async (event) => {
   const file = document.getElementById('video').files[0];
 
   if (!message) {
-    setStatus('Please add a gift message before generating the QR code.', true);
+    setStatus(t('upload.statusMissingMessage'), true);
     return;
   }
 
@@ -41,31 +110,22 @@ uploadForm.addEventListener('submit', async (event) => {
   }
 
   setLoadingState(true);
-  setStatus('Creating gift and generating your QR code', false, true);
+  setProgress(10);
+  setStatus(t('upload.statusLoading'), false, true);
   resultEl.classList.add('hidden');
   resultEl.classList.remove('success');
 
   try {
-    const response = await fetch(`${API_BASE}/api/gifts`, {
-      method: 'POST',
-      body: formData
-    });
+    const data = await createGift(formData);
 
-    const data = await response.json();
-
-    if (!response.ok) {
-      throw new Error(data.error || 'Could not create gift right now.');
-    }
-
-    // ✅ UPDATED VALIDATION (matches backend)
     if (!data.viewUrl || !data.qr) {
       throw new Error('Invalid gift response from server');
     }
 
-    // ✅ SET QR IMAGE
     qrImageEl.src = data.qr;
+    latestQrDataUrl = data.qr;
+    latestGiftUrl = data.viewUrl;
 
-    // ✅ USE BACKEND URL DIRECTLY
     openLinkEl.href = data.viewUrl;
     openLinkEl.target = '_blank';
     openLinkEl.rel = 'noopener noreferrer';
@@ -73,17 +133,51 @@ uploadForm.addEventListener('submit', async (event) => {
     resultEl.classList.remove('hidden');
     requestAnimationFrame(() => {
       resultEl.classList.add('success');
-      openLinkEl.classList.remove('cta-animated');
-      void openLinkEl.offsetWidth;
-      openLinkEl.classList.add('cta-animated');
+      launchSuccessBurst();
     });
 
-    setStatus('Gift created successfully. Save or share your QR code.');
+    setStatus(t('upload.statusSuccess'));
+    if (window.smartQRUI) {
+      window.smartQRUI.showToast('Gift created successfully!');
+    }
   } catch (err) {
     console.error('QR generation failed:', err);
-    alert('Failed to generate QR. Please try again.');
-    setStatus(err.message || 'Could not create gift right now.', true);
+    setStatus(err.message || t('upload.statusFailed'), true);
+    if (window.smartQRUI) {
+      window.smartQRUI.showToast('Could not create gift right now.');
+    }
   } finally {
     setLoadingState(false);
+    setProgress(0);
   }
 });
+
+copyLinkBtn.addEventListener('click', async () => {
+  if (!latestGiftUrl) return;
+  await navigator.clipboard.writeText(latestGiftUrl);
+  window.smartQRUI && window.smartQRUI.showToast('Gift link copied.');
+});
+
+shareBtn.addEventListener('click', async () => {
+  if (!latestGiftUrl) return;
+  if (navigator.share) {
+    await navigator.share({ title: 'My Smart QR Gift', url: latestGiftUrl });
+  } else {
+    await navigator.clipboard.writeText(latestGiftUrl);
+    window.smartQRUI && window.smartQRUI.showToast('Web Share unavailable. Link copied.');
+  }
+});
+
+downloadQrBtn.addEventListener('click', () => {
+  if (!latestQrDataUrl) return;
+  const link = document.createElement('a');
+  link.href = latestQrDataUrl;
+  link.download = 'smartqr-gift.png';
+  link.click();
+});
+
+document.addEventListener('smartqr:languagechange', () => {
+  submitBtn.textContent = t('upload.submit');
+});
+
+initTabs();

--- a/client/manifest.json
+++ b/client/manifest.json
@@ -1,20 +1,26 @@
 {
   "name": "Smart QR Gifting",
   "short_name": "SmartQR",
+  "description": "Create personalized gift pages with media and share them instantly via QR code.",
   "start_url": "/index.html",
+  "scope": "/",
   "display": "standalone",
+  "orientation": "portrait",
   "theme_color": "#7C3AED",
-  "background_color": "#020617",
+  "background_color": "#0B0F1A",
+  "categories": ["lifestyle", "productivity", "entertainment"],
   "icons": [
     {
-      "src": "/icons/icon-192.svg",
+      "src": "/icons/icon-192.png",
       "sizes": "192x192",
-      "type": "image/svg+xml"
+      "type": "image/png",
+      "purpose": "any maskable"
     },
     {
-      "src": "/icons/icon-512.svg",
+      "src": "/icons/icon-512.png",
       "sizes": "512x512",
-      "type": "image/svg+xml"
+      "type": "image/png",
+      "purpose": "any maskable"
     }
   ]
 }

--- a/client/offline.html
+++ b/client/offline.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Offline | Smart QR Gifting</title>
+  <link rel="stylesheet" href="/css/styles.css" />
+</head>
+<body>
+  <main class="page">
+    <section class="card" style="text-align:center;max-width:560px;">
+      <h1>You're offline</h1>
+      <p class="subtle">No worries—when your connection returns, you can keep creating and sharing gifts.</p>
+      <a href="/index.html" class="button-link">Try again</a>
+    </section>
+  </main>
+</body>
+</html>

--- a/client/service-worker.js
+++ b/client/service-worker.js
@@ -1,13 +1,19 @@
-const CACHE_NAME = 'smartqr-static-v1';
-const OFFLINE_URLS = [
+const STATIC_CACHE = 'smartqr-static-v2';
+const RUNTIME_CACHE = 'smartqr-runtime-v2';
+const OFFLINE_FALLBACK = '/offline.html';
+
+const STATIC_ASSETS = [
   '/',
   '/index.html',
   '/upload.html',
   '/view.html',
+  '/offline.html',
   '/css/styles.css',
   '/js/config.js',
   '/js/upload.js',
   '/js/view.js',
+  '/js/i18n.js',
+  '/js/app-shell.js',
   '/manifest.json',
   '/icons/icon-192.svg',
   '/icons/icon-512.svg'
@@ -15,9 +21,7 @@ const OFFLINE_URLS = [
 
 self.addEventListener('install', (event) => {
   self.skipWaiting();
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_URLS))
-  );
+  event.waitUntil(caches.open(STATIC_CACHE).then((cache) => cache.addAll(STATIC_ASSETS)));
 });
 
 self.addEventListener('activate', (event) => {
@@ -25,7 +29,7 @@ self.addEventListener('activate', (event) => {
     caches.keys().then((keys) =>
       Promise.all(
         keys
-          .filter((key) => key !== CACHE_NAME)
+          .filter((key) => ![STATIC_CACHE, RUNTIME_CACHE].includes(key))
           .map((key) => caches.delete(key))
       )
     ).then(() => self.clients.claim())
@@ -35,17 +39,37 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;
 
+  const requestUrl = new URL(event.request.url);
+  const isSameOrigin = requestUrl.origin === self.location.origin;
+
+  if (!isSameOrigin) return;
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(RUNTIME_CACHE).then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(async () => {
+          const cached = await caches.match(event.request);
+          return cached || caches.match(OFFLINE_FALLBACK);
+        })
+    );
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request).then((cached) => {
       if (cached) return cached;
-
       return fetch(event.request)
         .then((response) => {
           const copy = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          caches.open(RUNTIME_CACHE).then((cache) => cache.put(event.request, copy));
           return response;
         })
-        .catch(() => caches.match('/index.html'));
+        .catch(() => caches.match(OFFLINE_FALLBACK));
     })
   );
 });

--- a/client/upload.html
+++ b/client/upload.html
@@ -2,12 +2,16 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="theme-color" content="#7C3AED" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="SmartQR" />
   <title>Create Gift | Smart QR Gifting</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="apple-touch-icon" href="/icons/icon-192.svg" />
   <link rel="manifest" href="/manifest.json" />
   <link rel="stylesheet" href="css/styles.css" />
 </head>
@@ -15,73 +19,64 @@
   <main class="page">
     <div class="container">
       <div class="topbar">
-        <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode">🌙 Dark</button>
+        <a class="back-link" href="index.html">← Home</a>
+        <div class="header-actions">
+          <label class="sr-only" for="languageSwitcher">Language</label>
+          <select id="languageSwitcher" class="control-chip" aria-label="Language switcher"></select>
+          <button id="themeToggle" class="control-chip" type="button" aria-label="Toggle dark mode"></button>
+        </div>
       </div>
 
       <section class="card">
-        <a class="back-link" href="index.html">← Back</a>
-        <h1>Create your gift</h1>
-        <p class="subtle">Add a heartfelt message and an optional video. We'll generate a QR code ready to print or share.</p>
+        <h1 data-i18n="upload.title"></h1>
+        <p class="subtle" data-i18n="upload.subtitle"></p>
+
+        <div class="upload-tabs" role="tablist" aria-label="Upload type">
+          <button class="upload-tab active" role="tab" aria-selected="true" data-tab="text" data-i18n="upload.tabs.text"></button>
+          <button class="upload-tab" role="tab" aria-selected="false" data-tab="video" data-i18n="upload.tabs.video"></button>
+          <button class="upload-tab" role="tab" aria-selected="false" data-tab="audio" data-i18n="upload.tabs.audio"></button>
+          <button class="upload-tab" role="tab" aria-selected="false" data-tab="image" data-i18n="upload.tabs.image"></button>
+          <button class="upload-tab" role="tab" aria-selected="false" data-tab="gif" data-i18n="upload.tabs.gif"></button>
+        </div>
+
+        <div id="futureUploaderHint" class="empty-state" data-i18n="upload.futureHint"></div>
 
         <form id="uploadForm" class="gift-form" novalidate>
-          <label for="message">Gift message</label>
-          <textarea id="message" maxlength="300" placeholder="Write something memorable..." required></textarea>
+          <label for="message" data-i18n="upload.messageLabel"></label>
+          <textarea id="message" maxlength="300" data-i18n-placeholder="upload.messagePlaceholder" required></textarea>
 
-          <label for="video">Optional video (MP4, WebM, OGG, MOV · max 30MB)</label>
+          <label for="video" data-i18n="upload.videoLabel"></label>
           <input type="file" id="video" accept="video/mp4,video/webm,video/ogg,video/quicktime" />
 
-          <button id="submitBtn" type="submit">Generate QR code</button>
+          <div id="uploadProgressWrap" class="progress-wrap hidden" aria-live="polite">
+            <div class="progress-bar"><span id="uploadProgressBar"></span></div>
+            <small id="uploadProgressText">0%</small>
+          </div>
+
+          <button id="submitBtn" type="submit" data-i18n="upload.submit"></button>
         </form>
 
         <p id="status" class="status" aria-live="polite"></p>
 
         <section id="result" class="result hidden" aria-live="polite">
-          <h2>Your gift is ready 🎉</h2>
+          <h2 data-i18n="upload.resultTitle"></h2>
           <img id="qrImage" alt="Gift QR code" />
-          <a id="openLink" class="button-link" target="_blank" rel="noopener noreferrer">Open gift page</a>
+          <a id="openLink" class="button-link" target="_blank" rel="noopener noreferrer" data-i18n="upload.openGift"></a>
+          <div class="action-row">
+            <button id="copyLinkBtn" class="button-link button-secondary" type="button" data-i18n="upload.copyLink"></button>
+            <button id="shareBtn" class="button-link button-secondary" type="button" data-i18n="upload.share"></button>
+            <button id="downloadQrBtn" class="button-link button-secondary" type="button" data-i18n="upload.downloadQr"></button>
+          </div>
+          <div id="successConfetti" class="success-burst" aria-hidden="true"></div>
         </section>
       </section>
     </div>
   </main>
 
-  <script>
-    (function () {
-      const root = document.documentElement;
-      const toggle = document.getElementById('themeToggle');
-      const storageKey = 'smartqr-theme';
-      const media = window.matchMedia('(prefers-color-scheme: dark)');
+  <div id="toastRegion" class="toast-region" aria-live="polite" aria-atomic="true"></div>
 
-      function applyTheme(theme) {
-        root.setAttribute('data-theme', theme);
-        toggle.textContent = theme === 'dark' ? '☀️ Light' : '🌙 Dark';
-      }
-
-      const saved = localStorage.getItem(storageKey);
-      applyTheme(saved || (media.matches ? 'dark' : 'light'));
-
-      toggle.addEventListener('click', function () {
-        const current = root.getAttribute('data-theme') || 'light';
-        const next = current === 'dark' ? 'light' : 'dark';
-        localStorage.setItem(storageKey, next);
-        applyTheme(next);
-      });
-
-      media.addEventListener('change', function (event) {
-        if (!localStorage.getItem(storageKey)) {
-          applyTheme(event.matches ? 'dark' : 'light');
-        }
-      });
-
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', function () {
-          navigator.serviceWorker.register('/service-worker.js').catch(function (error) {
-            console.warn('Service worker registration failed:', error);
-          });
-        });
-      }
-    })();
-  </script>
-
+  <script src="js/i18n.js"></script>
+  <script src="js/app-shell.js"></script>
   <script src="js/config.js"></script>
   <script src="js/upload.js"></script>
 </body>


### PR DESCRIPTION
### Motivation
- Make the branch safe for PR creation by removing binary PNG assets while keeping the premium frontend, PWA and i18n improvements intact.
- Prevent service worker precache/install failures caused by missing PNG files by routing runtime references to SVGs while leaving `manifest.json` icon entries unchanged as requested.

### Description
- Removed binary icon files `client/icons/icon-192.png` and `client/icons/icon-512.png` from the branch.
- Updated runtime/front-end references to use SVG icons: `apple-touch-icon` in `client/index.html` and `client/upload.html` now points to `/icons/icon-192.svg` and the service worker precache (`client/service-worker.js`) caches `/icons/icon-192.svg` and `/icons/icon-512.svg`.
- Preserved `client/manifest.json` icon entries pointing to the original PNGs to keep manifest references intact as requested.
- Kept and committed all UI improvements from the previous overhaul and added/updated supportive files: `client/js/app-shell.js`, `client/js/i18n.js`, `client/offline.html`, `client/js/upload.js`, `client/css/styles.css`, and `client/upload.html`.

### Testing
- Ran `node --check client/service-worker.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4805f9f88329a12669d8b8311197)