### PR TITLE
Add premium browser voice recording to upload flow

### DIFF
--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -115,6 +115,85 @@ button:focus-visible, .button-link:focus-visible, textarea:focus-visible, input:
 .upload-tab.active { background: var(--gradient); color: #fff; border-color: transparent; }
 
 .empty-state { border: 1px dashed var(--border); border-radius: 12px; padding: 0.8rem; color: var(--muted); margin-bottom: 0.8rem; }
+
+.audio-recorder {
+  margin-top: 0.6rem;
+  padding: 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(14px);
+  display: grid;
+  gap: 0.7rem;
+}
+
+.audio-recorder-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.audio-title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.recording-timer {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  font-size: 0.9rem;
+  padding: 0.28rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--glass);
+}
+
+.audio-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.audio-btn {
+  flex: 1 1 140px;
+  min-height: 44px;
+}
+
+.audio-btn-record {
+  position: relative;
+}
+
+.record-pulse {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.55);
+}
+
+.audio-btn-record.is-recording .record-pulse {
+  animation: pulse 1.2s ease-out infinite;
+}
+
+.audio-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+  transform: none;
+  box-shadow: none;
+}
+
+.audio-preview {
+  width: 100%;
+}
+
+.audio-error {
+  margin: 0;
+  color: var(--error);
+  font-size: 0.9rem;
+}
+
 .progress-wrap { display: grid; gap: 0.3rem; }
 .progress-bar { height: 8px; background: rgba(148, 163, 184, 0.24); border-radius: 999px; overflow: hidden; }
 .progress-bar span { display: block; height: 100%; width: 0; background: var(--gradient); transition: width 160ms ease; }
@@ -159,6 +238,11 @@ button:focus-visible, .button-link:focus-visible, textarea:focus-visible, input:
 @keyframes spin { to { transform: rotate(360deg); } }
 @keyframes dots { 0% { content: ' .'; } 33% { content: ' ..'; } 66% { content: ' ...'; } 100% { content: ' ....'; } }
 @keyframes burst { 0% { opacity: 0; transform: translateY(8px) scale(.7); } 50% { opacity: 1; transform: translateY(0) scale(1.2); } 100% { opacity: 0; transform: translateY(-5px) scale(1); } }
+@keyframes pulse {
+  0% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.45); transform: scale(1); }
+  70% { box-shadow: 0 0 0 10px rgba(255, 255, 255, 0); transform: scale(1.08); }
+  100% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0); transform: scale(1); }
+}
 
 @media (min-width: 768px) {
   .hero { grid-template-columns: 1.35fr 1fr; align-items: center; }
@@ -166,4 +250,5 @@ button:focus-visible, .button-link:focus-visible, textarea:focus-visible, input:
 }
 @media (max-width: 767px) {
   button, .button-link { width: 100%; }
+  .audio-actions .audio-btn { width: 100%; }
 }

--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -13,9 +13,22 @@ const progressText = document.getElementById('uploadProgressText');
 const successConfetti = document.getElementById('successConfetti');
 const tabs = document.querySelectorAll('.upload-tab');
 const futureHint = document.getElementById('futureUploaderHint');
+const audioRecorderPanel = document.getElementById('audioRecorderPanel');
+const recordBtn = document.getElementById('recordBtn');
+const stopBtn = document.getElementById('stopBtn');
+const reRecordBtn = document.getElementById('reRecordBtn');
+const audioPreview = document.getElementById('audioPreview');
+const recordingTimer = document.getElementById('recordingTimer');
+const audioError = document.getElementById('audioError');
 
 let latestGiftUrl = '';
 let latestQrDataUrl = '';
+let mediaRecorder = null;
+let recordingChunks = [];
+let recordingTimerId = null;
+let recordingSeconds = 0;
+let audioBlob = null;
+let audioStream = null;
 
 function t(key) {
   return window.smartQRI18n ? window.smartQRI18n.t(key) : key;
@@ -38,6 +51,167 @@ function setLoadingState(isLoading) {
 function setProgress(percent) {
   progressBar.style.width = `${Math.max(5, percent)}%`;
   progressText.textContent = `${Math.round(percent)}%`;
+}
+
+
+function formatRecordingTime(totalSeconds) {
+  const minutes = String(Math.floor(totalSeconds / 60)).padStart(2, '0');
+  const seconds = String(totalSeconds % 60).padStart(2, '0');
+  return `${minutes}:${seconds}`;
+}
+
+function setAudioError(message = '') {
+  const hasError = Boolean(message);
+  audioError.textContent = message;
+  audioError.classList.toggle('hidden', !hasError);
+}
+
+function setRecorderButtons({ isRecording = false, hasRecording = false } = {}) {
+  recordBtn.disabled = isRecording;
+  stopBtn.disabled = !isRecording;
+  reRecordBtn.disabled = isRecording || !hasRecording;
+  reRecordBtn.classList.toggle('hidden', !hasRecording);
+  recordBtn.classList.toggle('is-recording', isRecording);
+}
+
+function resetRecordingTimer() {
+  recordingSeconds = 0;
+  recordingTimer.textContent = formatRecordingTime(recordingSeconds);
+}
+
+function startRecordingTimer() {
+  clearInterval(recordingTimerId);
+  recordingTimerId = window.setInterval(() => {
+    recordingSeconds += 1;
+    recordingTimer.textContent = formatRecordingTime(recordingSeconds);
+  }, 1000);
+}
+
+function stopRecordingTimer() {
+  clearInterval(recordingTimerId);
+  recordingTimerId = null;
+}
+
+function clearAudioPreview() {
+  if (audioPreview.dataset.objectUrl) {
+    URL.revokeObjectURL(audioPreview.dataset.objectUrl);
+    delete audioPreview.dataset.objectUrl;
+  }
+  audioPreview.pause();
+  audioPreview.removeAttribute('src');
+  audioPreview.load();
+  audioPreview.classList.add('hidden');
+}
+
+function showAudioPreview(blob) {
+  clearAudioPreview();
+  const objectUrl = URL.createObjectURL(blob);
+  audioPreview.src = objectUrl;
+  audioPreview.dataset.objectUrl = objectUrl;
+  audioPreview.classList.remove('hidden');
+}
+
+function stopMediaTracks() {
+  if (!audioStream) return;
+  audioStream.getTracks().forEach((track) => track.stop());
+  audioStream = null;
+}
+
+async function startRecording() {
+  setAudioError('');
+
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia || typeof MediaRecorder === 'undefined') {
+    setAudioError('Audio recording is not supported in this browser.');
+    return;
+  }
+
+  try {
+    audioStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const options = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+      ? { mimeType: 'audio/webm;codecs=opus' }
+      : {};
+
+    mediaRecorder = new MediaRecorder(audioStream, options);
+    recordingChunks = [];
+
+    mediaRecorder.addEventListener('dataavailable', (event) => {
+      if (event.data && event.data.size > 0) {
+        recordingChunks.push(event.data);
+      }
+    });
+
+    mediaRecorder.addEventListener('stop', () => {
+      stopRecordingTimer();
+      stopMediaTracks();
+
+      if (!recordingChunks.length) {
+        setRecorderButtons({ isRecording: false, hasRecording: false });
+        setAudioError('No audio was captured. Please try recording again.');
+        return;
+      }
+
+      audioBlob = new Blob(recordingChunks, { type: mediaRecorder.mimeType || 'audio/webm' });
+      showAudioPreview(audioBlob);
+      setRecorderButtons({ isRecording: false, hasRecording: true });
+    });
+
+    mediaRecorder.addEventListener('error', () => {
+      stopRecordingTimer();
+      stopMediaTracks();
+      setRecorderButtons({ isRecording: false, hasRecording: Boolean(audioBlob) });
+      setAudioError('Recording failed. Please try again.');
+    });
+
+    audioBlob = null;
+    clearAudioPreview();
+    resetRecordingTimer();
+    setRecorderButtons({ isRecording: true, hasRecording: false });
+    startRecordingTimer();
+    mediaRecorder.start();
+  } catch (error) {
+    stopRecordingTimer();
+    stopMediaTracks();
+    setRecorderButtons({ isRecording: false, hasRecording: Boolean(audioBlob) });
+    if (error && (error.name === 'NotAllowedError' || error.name === 'SecurityError')) {
+      setAudioError('Microphone permission was denied. Please allow microphone access to record.');
+    } else {
+      setAudioError('Unable to access microphone. Please check your audio settings.');
+    }
+  }
+}
+
+function stopRecording() {
+  if (!mediaRecorder || mediaRecorder.state !== 'recording') return;
+  mediaRecorder.stop();
+}
+
+function resetAudioRecording() {
+  audioBlob = null;
+  recordingChunks = [];
+  stopRecordingTimer();
+  resetRecordingTimer();
+  clearAudioPreview();
+  setAudioError('');
+  setRecorderButtons({ isRecording: false, hasRecording: false });
+}
+
+function initAudioRecorder() {
+  if (!recordBtn || !stopBtn || !reRecordBtn || !audioPreview) return;
+
+  resetAudioRecording();
+
+  recordBtn.addEventListener('click', () => {
+    if (recordBtn.disabled) return;
+    startRecording();
+  });
+
+  stopBtn.addEventListener('click', () => {
+    stopRecording();
+  });
+
+  reRecordBtn.addEventListener('click', () => {
+    resetAudioRecording();
+  });
 }
 
 function createGift(formData) {
@@ -85,8 +259,10 @@ function initTabs() {
       tab.setAttribute('aria-selected', 'true');
 
       const isVideo = tab.dataset.tab === 'video' || tab.dataset.tab === 'text';
-      futureHint.classList.toggle('hidden', isVideo);
+      const isAudio = tab.dataset.tab === 'audio';
+      futureHint.classList.toggle('hidden', isVideo || isAudio);
       document.getElementById('video').disabled = tab.dataset.tab !== 'video' && tab.dataset.tab !== 'text';
+      audioRecorderPanel.classList.toggle('hidden', !isAudio);
     });
   });
 }
@@ -107,6 +283,10 @@ uploadForm.addEventListener('submit', async (event) => {
 
   if (file) {
     formData.append('video', file);
+  }
+
+  if (audioBlob) {
+    formData.append('audio', audioBlob, 'recording.webm');
   }
 
   setLoadingState(true);
@@ -181,3 +361,4 @@ document.addEventListener('smartqr:languagechange', () => {
 });
 
 initTabs();
+initAudioRecorder();

--- a/client/upload.html
+++ b/client/upload.html
@@ -48,6 +48,26 @@
           <label for="video" data-i18n="upload.videoLabel"></label>
           <input type="file" id="video" accept="video/mp4,video/webm,video/ogg,video/quicktime" />
 
+          <section id="audioRecorderPanel" class="audio-recorder hidden" aria-live="polite">
+            <div class="audio-recorder-head">
+              <p class="audio-title">🎤 Audio Gift Recorder</p>
+              <span id="recordingTimer" class="recording-timer" aria-label="Recording timer">00:00</span>
+            </div>
+
+            <div class="audio-actions">
+              <button id="recordBtn" type="button" class="audio-btn audio-btn-record">
+                <span id="recordPulse" class="record-pulse" aria-hidden="true"></span>
+                Record
+              </button>
+              <button id="stopBtn" type="button" class="audio-btn button-secondary" disabled>Stop</button>
+              <button id="reRecordBtn" type="button" class="audio-btn button-secondary hidden" disabled>Re-record</button>
+            </div>
+
+            <p id="audioError" class="audio-error hidden" role="alert"></p>
+
+            <audio id="audioPreview" class="audio-preview hidden" controls preload="metadata"></audio>
+          </section>
+
           <div id="uploadProgressWrap" class="progress-wrap hidden" aria-live="polite">
             <div class="progress-bar"><span id="uploadProgressBar"></span></div>
             <small id="uploadProgressText">0%</small>


### PR DESCRIPTION
### Motivation
- Provide a PREMIUM audio recording option so users can record and attach voice gifts directly in the upload UI.
- Keep the change additive and preserve the existing API contract and video upload behavior so no existing flows break.
- Improve UX with polished interactions: recording timer, pulse animation, disabled states, error handling, and mobile-first layout.

### Description
- Added an audio recorder panel to `client/upload.html` with accessible elements and existing IDs preserved (Record, Stop, Re-record, timer, preview, and inline error area).
- Implemented a MediaRecorder-based flow in `client/js/upload.js` to start/stop recording, collect chunks into an in-memory `Blob`, show audio preview, manage timer, and handle mic-permission and runtime errors.
- Conditionally append the recorded audio to the submission payload using `formData.append('audio', audioBlob, 'recording.webm')` only when a recording exists, leaving the existing `video` append unchanged.
- Added glassmorphism-consistent styles and micro-interactions in `client/css/styles.css`, including a pulse animation and responsive button layout to match dark/light themes and mobile-first requirements.

### Testing
- Static JS checks succeeded with `node --check client/js/upload.js` and `node --check server/server.js`.
- Rendered the updated page via `python -m http.server 4173` and captured a Playwright screenshot of the Audio tab to validate UI rendering and responsiveness.
- Playwright run and screenshot capture completed successfully, and no runtime syntax errors were detected during automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4b2d6c848329ac68586356830e5b)