### PR TITLE
Add Text-to-Speech auto-voice generator to Audio tab

### DIFF
--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -188,6 +188,76 @@ button:focus-visible, .button-link:focus-visible, textarea:focus-visible, input:
   width: 100%;
 }
 
+.tts-generator {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.7rem;
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  backdrop-filter: blur(12px);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.tts-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.tts-title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 0.92rem;
+}
+
+.tts-state {
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.tts-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tts-voice-select {
+  flex: 1 1 210px;
+  min-height: 44px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  color: var(--text);
+  padding: 0.65rem 0.75rem;
+  font: inherit;
+}
+
+.tts-generate-btn {
+  flex: 1 1 170px;
+  position: relative;
+}
+
+.tts-generate-btn.is-generating .tts-pulse {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.55);
+  animation: pulse 1.1s ease-out infinite;
+}
+
+.tts-preview {
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 220ms ease, transform 220ms ease;
+}
+
+.tts-preview.tts-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 .audio-error {
   margin: 0;
   color: var(--error);
@@ -251,4 +321,5 @@ button:focus-visible, .button-link:focus-visible, textarea:focus-visible, input:
 @media (max-width: 767px) {
   button, .button-link { width: 100%; }
   .audio-actions .audio-btn { width: 100%; }
+  .tts-controls > * { width: 100%; }
 }

--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -20,6 +20,12 @@ const reRecordBtn = document.getElementById('reRecordBtn');
 const audioPreview = document.getElementById('audioPreview');
 const recordingTimer = document.getElementById('recordingTimer');
 const audioError = document.getElementById('audioError');
+const messageEl = document.getElementById('message');
+const ttsVoiceSelect = document.getElementById('ttsVoiceSelect');
+const generateVoiceBtn = document.getElementById('generateVoiceBtn');
+const ttsPreview = document.getElementById('ttsPreview');
+const ttsError = document.getElementById('ttsError');
+const ttsLoadingState = document.getElementById('ttsLoadingState');
 
 let latestGiftUrl = '';
 let latestQrDataUrl = '';
@@ -29,6 +35,9 @@ let recordingTimerId = null;
 let recordingSeconds = 0;
 let audioBlob = null;
 let audioStream = null;
+let ttsGenerated = false;
+let ttsVoices = [];
+let ttsIsGenerating = false;
 
 function t(key) {
   return window.smartQRI18n ? window.smartQRI18n.t(key) : key;
@@ -64,6 +73,53 @@ function setAudioError(message = '') {
   const hasError = Boolean(message);
   audioError.textContent = message;
   audioError.classList.toggle('hidden', !hasError);
+}
+
+function setTTSError(message = '') {
+  const hasError = Boolean(message);
+  ttsError.textContent = message;
+  ttsError.classList.toggle('hidden', !hasError);
+}
+
+function clearTTSAudioPreview() {
+  if (!ttsPreview) return;
+  if (ttsPreview.dataset.objectUrl) {
+    URL.revokeObjectURL(ttsPreview.dataset.objectUrl);
+    delete ttsPreview.dataset.objectUrl;
+  }
+  ttsPreview.pause();
+  ttsPreview.removeAttribute('src');
+  ttsPreview.load();
+  ttsPreview.classList.remove('tts-visible');
+  ttsPreview.classList.add('hidden');
+}
+
+function showTTSAudioPreview(blob) {
+  clearTTSAudioPreview();
+  const objectUrl = URL.createObjectURL(blob);
+  ttsPreview.src = objectUrl;
+  ttsPreview.dataset.objectUrl = objectUrl;
+  ttsPreview.classList.remove('hidden');
+  requestAnimationFrame(() => {
+    ttsPreview.classList.add('tts-visible');
+  });
+}
+
+function setTTSLoadingState(isLoading) {
+  ttsIsGenerating = isLoading;
+  generateVoiceBtn.disabled = isLoading;
+  generateVoiceBtn.classList.toggle('is-generating', isLoading);
+  generateVoiceBtn.setAttribute('aria-busy', String(isLoading));
+  ttsLoadingState.classList.toggle('hidden', !isLoading);
+}
+
+function setGeneratedAudioBlob(blob, source = 'recording') {
+  audioBlob = blob;
+  ttsGenerated = source === 'tts';
+  if (source === 'recording') {
+    clearTTSAudioPreview();
+    setTTSError('');
+  }
 }
 
 function setRecorderButtons({ isRecording = false, hasRecording = false } = {}) {
@@ -150,7 +206,8 @@ async function startRecording() {
         return;
       }
 
-      audioBlob = new Blob(recordingChunks, { type: mediaRecorder.mimeType || 'audio/webm' });
+      const recordedBlob = new Blob(recordingChunks, { type: mediaRecorder.mimeType || 'audio/webm' });
+      setGeneratedAudioBlob(recordedBlob, 'recording');
       showAudioPreview(audioBlob);
       setRecorderButtons({ isRecording: false, hasRecording: true });
     });
@@ -186,7 +243,7 @@ function stopRecording() {
 }
 
 function resetAudioRecording() {
-  audioBlob = null;
+  setGeneratedAudioBlob(null);
   recordingChunks = [];
   stopRecordingTimer();
   resetRecordingTimer();
@@ -196,9 +253,17 @@ function resetAudioRecording() {
 }
 
 function initAudioRecorder() {
-  if (!recordBtn || !stopBtn || !reRecordBtn || !audioPreview) return;
+  if (!recordBtn || !stopBtn || !reRecordBtn || !audioPreview || !generateVoiceBtn || !ttsVoiceSelect || !ttsPreview || !ttsError || !ttsLoadingState) return;
 
   resetAudioRecording();
+  setTTSError('');
+  clearTTSAudioPreview();
+  setTTSLoadingState(false);
+  populateVoiceOptions();
+
+  if ('speechSynthesis' in window) {
+    window.speechSynthesis.addEventListener('voiceschanged', populateVoiceOptions);
+  }
 
   recordBtn.addEventListener('click', () => {
     if (recordBtn.disabled) return;
@@ -212,6 +277,145 @@ function initAudioRecorder() {
   reRecordBtn.addEventListener('click', () => {
     resetAudioRecording();
   });
+
+  generateVoiceBtn.addEventListener('click', () => {
+    generateVoiceFromText();
+  });
+
+  generateVoiceBtn.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      generateVoiceFromText();
+    }
+  });
+}
+
+function populateVoiceOptions() {
+  if (!ttsVoiceSelect) return;
+
+  ttsVoices = window.speechSynthesis ? window.speechSynthesis.getVoices() : [];
+  ttsVoiceSelect.innerHTML = '';
+
+  if (!ttsVoices.length) {
+    const fallback = document.createElement('option');
+    fallback.value = '';
+    fallback.textContent = 'Default voice';
+    ttsVoiceSelect.appendChild(fallback);
+    ttsVoiceSelect.disabled = true;
+    return;
+  }
+
+  ttsVoiceSelect.disabled = false;
+  ttsVoices.forEach((voice, index) => {
+    const option = document.createElement('option');
+    option.value = String(index);
+    option.textContent = `${voice.name} (${voice.lang})`;
+    ttsVoiceSelect.appendChild(option);
+  });
+}
+
+async function generateVoiceFromText() {
+  if (ttsIsGenerating) return;
+  setTTSError('');
+
+  if (!messageEl || !messageEl.value.trim()) {
+    setTTSError('Please enter a message before generating auto voice.');
+    return;
+  }
+
+  if (!('speechSynthesis' in window) || typeof SpeechSynthesisUtterance === 'undefined') {
+    setTTSError('Auto voice not supported on this browser');
+    return;
+  }
+
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia || typeof MediaRecorder === 'undefined') {
+    setTTSError('Audio capture is not supported in this browser.');
+    return;
+  }
+
+  let stream;
+  let recorder;
+  let audioContext;
+  let destination;
+
+  try {
+    setTTSLoadingState(true);
+    clearTTSAudioPreview();
+
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    destination = audioContext.createMediaStreamDestination();
+
+    const sourceNode = audioContext.createMediaStreamSource(stream);
+    sourceNode.connect(destination);
+
+    const options = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+      ? { mimeType: 'audio/webm;codecs=opus' }
+      : {};
+
+    const chunks = [];
+    recorder = new MediaRecorder(destination.stream, options);
+
+    const utterance = new SpeechSynthesisUtterance(messageEl.value.trim());
+    const selectedVoiceIndex = Number(ttsVoiceSelect.value);
+    if (!Number.isNaN(selectedVoiceIndex) && ttsVoices[selectedVoiceIndex]) {
+      utterance.voice = ttsVoices[selectedVoiceIndex];
+      utterance.lang = ttsVoices[selectedVoiceIndex].lang;
+    }
+
+    const ttsBlob = await new Promise((resolve, reject) => {
+      const cleanup = () => {
+        recorder.removeEventListener('dataavailable', onData);
+      };
+
+      const onData = (event) => {
+        if (event.data && event.data.size > 0) chunks.push(event.data);
+      };
+
+      recorder.addEventListener('dataavailable', onData);
+      recorder.addEventListener('error', () => {
+        cleanup();
+        reject(new Error('Auto voice generation failed.'));
+      });
+
+      recorder.addEventListener('stop', () => {
+        cleanup();
+        if (!chunks.length) {
+          reject(new Error('No generated audio was captured.'));
+          return;
+        }
+        resolve(new Blob(chunks, { type: recorder.mimeType || 'audio/webm' }));
+      }, { once: true });
+
+      utterance.addEventListener('end', () => {
+        if (recorder.state === 'recording') {
+          recorder.stop();
+        }
+      }, { once: true });
+
+      utterance.addEventListener('error', () => {
+        if (recorder.state === 'recording') recorder.stop();
+        reject(new Error('Could not synthesize the message.'));
+      }, { once: true });
+
+      recorder.start();
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(utterance);
+    });
+
+    setGeneratedAudioBlob(ttsBlob, 'tts');
+    clearAudioPreview();
+    setRecorderButtons({ isRecording: false, hasRecording: false });
+    showTTSAudioPreview(ttsBlob);
+    window.smartQRUI && window.smartQRUI.showToast('Auto voice generated successfully.');
+  } catch (error) {
+    setTTSError(error.message || 'Unable to generate auto voice right now.');
+  } finally {
+    if (recorder && recorder.state === 'recording') recorder.stop();
+    if (stream) stream.getTracks().forEach((track) => track.stop());
+    if (audioContext) audioContext.close();
+    setTTSLoadingState(false);
+  }
 }
 
 function createGift(formData) {
@@ -286,7 +490,7 @@ uploadForm.addEventListener('submit', async (event) => {
   }
 
   if (audioBlob) {
-    formData.append('audio', audioBlob, 'recording.webm');
+    formData.append('audio', audioBlob, ttsGenerated ? 'tts.webm' : 'recording.webm');
   }
 
   setLoadingState(true);

--- a/client/upload.html
+++ b/client/upload.html
@@ -48,7 +48,7 @@
           <label for="video" data-i18n="upload.videoLabel"></label>
           <input type="file" id="video" accept="video/mp4,video/webm,video/ogg,video/quicktime" />
 
-          <section id="audioRecorderPanel" class="audio-recorder hidden" aria-live="polite">
+          <section id="audioRecorderPanel" class="audio-recorder hidden" aria-live="polite" data-audio-recorder="true">
             <div class="audio-recorder-head">
               <p class="audio-title">🎤 Audio Gift Recorder</p>
               <span id="recordingTimer" class="recording-timer" aria-label="Recording timer">00:00</span>
@@ -66,6 +66,23 @@
             <p id="audioError" class="audio-error hidden" role="alert"></p>
 
             <audio id="audioPreview" class="audio-preview hidden" controls preload="metadata"></audio>
+
+            <section class="tts-generator" aria-live="polite">
+              <div class="tts-head">
+                <p class="tts-title">✨ Auto voice generator</p>
+                <span id="ttsLoadingState" class="tts-state hidden">Generating...</span>
+              </div>
+              <div class="tts-controls">
+                <label for="ttsVoiceSelect" class="sr-only">Select voice</label>
+                <select id="ttsVoiceSelect" class="tts-voice-select" aria-label="Select auto voice"></select>
+                <button id="generateVoiceBtn" type="button" class="audio-btn tts-generate-btn" aria-label="Generate voice from typed message">
+                  <span class="tts-pulse" aria-hidden="true"></span>
+                  Generate from text
+                </button>
+              </div>
+              <p id="ttsError" class="audio-error hidden" role="alert"></p>
+              <audio id="ttsPreview" class="audio-preview tts-preview hidden" controls preload="metadata" aria-label="Generated voice preview"></audio>
+            </section>
           </section>
 
           <div id="uploadProgressWrap" class="progress-wrap hidden" aria-live="polite">


### PR DESCRIPTION
### Motivation
- Improve the audio upload UX by letting users generate an auto voice from the typed message as an alternative to recording, while preserving the existing recorder experience and upload contract. 
- Provide a polished, accessible and mobile-safe UI (glassmorphism style, loading/pulse, preview) that integrates with the current form flow and does not rename existing IDs or keys.

### Description
- Added a TTS UI block under the existing recorder including a voice selector, `Generate from text` button, loading state label, inline error element and a hidden-until-generated `<audio>` preview, and annotated the recorder container with `data-audio-recorder="true"` (file: `client/upload.html`).
- Implemented modular TTS logic in `client/js/upload.js` using `speechSynthesis` and `SpeechSynthesisUtterance`, capturing output with `AudioContext` + `MediaRecorder`, producing an `audioBlob` and showing a preview without touching the existing MediaRecorder recording flow; generated audio is appended to the upload `FormData` only when present as `formData.append('audio', audioBlob, 'tts.webm')` otherwise recordings remain `recording.webm`.
- Added robust guards and validations including empty-message validation, browser capability checks (`speechSynthesis` and `MediaRecorder`), single-click prevention via disabled/loading states, keyboard support on the generate control, ARIA labels, and smooth preview fade-in (file: `client/js/upload.js`, `client/css/styles.css`).
- Styled the TTS module with responsive glassmorphism, a subtle loading pulse, disabled states, and preserved mobile layout behavior (file: `client/css/styles.css`).

### Testing
- `node --check client/js/upload.js` passed to verify JS syntax and integration points. 
- Started the server process (`server/server.js`) as a smoke test and observed successful boot output in this environment. 
- Attempted an automated UI screenshot using Playwright (served client via `python -m http.server`) to validate the Audio tab UI, but the headless browser run timed out / crashed in this environment so no screenshot artifact could be produced; TTS logic and guards remain unit-testable in-browser and were developed to be non-breaking.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4f8432608329a403b32c65d3005c)