### PR TITLE
feat(upload): soft-disable auto voice generator with premium “Coming soon” UX

### DIFF
--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -238,6 +238,18 @@ button:focus-visible, .button-link:focus-visible, textarea:focus-visible, input:
   position: relative;
 }
 
+.tts-generate-btn.is-disabled {
+  opacity: 0.6;
+  filter: saturate(0.8);
+}
+
+.tts-helper {
+  margin: -0.1rem 0 0;
+  font-size: 0.82rem;
+  color: color-mix(in srgb, var(--muted) 82%, var(--text));
+  opacity: 0.82;
+}
+
 .tts-generate-btn.is-generating .tts-pulse {
   width: 10px;
   height: 10px;

--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -81,6 +81,13 @@ function setTTSError(message = '') {
   ttsError.classList.toggle('hidden', !hasError);
 }
 
+function showComingSoonTTSNotice() {
+  setTTSError('');
+  if (window.smartQRUI) {
+    window.smartQRUI.showToast('✨ Auto voice generation coming soon');
+  }
+}
+
 function clearTTSAudioPreview() {
   if (!ttsPreview) return;
   if (ttsPreview.dataset.objectUrl) {
@@ -107,7 +114,10 @@ function showTTSAudioPreview(blob) {
 
 function setTTSLoadingState(isLoading) {
   ttsIsGenerating = isLoading;
-  generateVoiceBtn.disabled = isLoading;
+  if (!generateVoiceBtn || !ttsLoadingState) return;
+  generateVoiceBtn.disabled = false;
+  generateVoiceBtn.classList.add('is-disabled');
+  generateVoiceBtn.setAttribute('aria-disabled', 'true');
   generateVoiceBtn.classList.toggle('is-generating', isLoading);
   generateVoiceBtn.setAttribute('aria-busy', String(isLoading));
   ttsLoadingState.classList.toggle('hidden', !isLoading);
@@ -260,6 +270,8 @@ function initAudioRecorder() {
   clearTTSAudioPreview();
   setTTSLoadingState(false);
   populateVoiceOptions();
+  generateVoiceBtn.removeAttribute('disabled');
+  generateVoiceBtn.title = 'Coming soon';
 
   if ('speechSynthesis' in window) {
     window.speechSynthesis.addEventListener('voiceschanged', populateVoiceOptions);
@@ -278,14 +290,15 @@ function initAudioRecorder() {
     resetAudioRecording();
   });
 
-  generateVoiceBtn.addEventListener('click', () => {
-    generateVoiceFromText();
+  generateVoiceBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    showComingSoonTTSNotice();
   });
 
   generateVoiceBtn.addEventListener('keydown', (event) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
-      generateVoiceFromText();
+      showComingSoonTTSNotice();
     }
   });
 }
@@ -316,106 +329,9 @@ function populateVoiceOptions() {
 
 async function generateVoiceFromText() {
   if (ttsIsGenerating) return;
-  setTTSError('');
 
-  if (!messageEl || !messageEl.value.trim()) {
-    setTTSError('Please enter a message before generating auto voice.');
-    return;
-  }
-
-  if (!('speechSynthesis' in window) || typeof SpeechSynthesisUtterance === 'undefined') {
-    setTTSError('Auto voice not supported on this browser');
-    return;
-  }
-
-  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia || typeof MediaRecorder === 'undefined') {
-    setTTSError('Audio capture is not supported in this browser.');
-    return;
-  }
-
-  let stream;
-  let recorder;
-  let audioContext;
-  let destination;
-
-  try {
-    setTTSLoadingState(true);
-    clearTTSAudioPreview();
-
-    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    audioContext = new (window.AudioContext || window.webkitAudioContext)();
-    destination = audioContext.createMediaStreamDestination();
-
-    const sourceNode = audioContext.createMediaStreamSource(stream);
-    sourceNode.connect(destination);
-
-    const options = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-      ? { mimeType: 'audio/webm;codecs=opus' }
-      : {};
-
-    const chunks = [];
-    recorder = new MediaRecorder(destination.stream, options);
-
-    const utterance = new SpeechSynthesisUtterance(messageEl.value.trim());
-    const selectedVoiceIndex = Number(ttsVoiceSelect.value);
-    if (!Number.isNaN(selectedVoiceIndex) && ttsVoices[selectedVoiceIndex]) {
-      utterance.voice = ttsVoices[selectedVoiceIndex];
-      utterance.lang = ttsVoices[selectedVoiceIndex].lang;
-    }
-
-    const ttsBlob = await new Promise((resolve, reject) => {
-      const cleanup = () => {
-        recorder.removeEventListener('dataavailable', onData);
-      };
-
-      const onData = (event) => {
-        if (event.data && event.data.size > 0) chunks.push(event.data);
-      };
-
-      recorder.addEventListener('dataavailable', onData);
-      recorder.addEventListener('error', () => {
-        cleanup();
-        reject(new Error('Auto voice generation failed.'));
-      });
-
-      recorder.addEventListener('stop', () => {
-        cleanup();
-        if (!chunks.length) {
-          reject(new Error('No generated audio was captured.'));
-          return;
-        }
-        resolve(new Blob(chunks, { type: recorder.mimeType || 'audio/webm' }));
-      }, { once: true });
-
-      utterance.addEventListener('end', () => {
-        if (recorder.state === 'recording') {
-          recorder.stop();
-        }
-      }, { once: true });
-
-      utterance.addEventListener('error', () => {
-        if (recorder.state === 'recording') recorder.stop();
-        reject(new Error('Could not synthesize the message.'));
-      }, { once: true });
-
-      recorder.start();
-      window.speechSynthesis.cancel();
-      window.speechSynthesis.speak(utterance);
-    });
-
-    setGeneratedAudioBlob(ttsBlob, 'tts');
-    clearAudioPreview();
-    setRecorderButtons({ isRecording: false, hasRecording: false });
-    showTTSAudioPreview(ttsBlob);
-    window.smartQRUI && window.smartQRUI.showToast('Auto voice generated successfully.');
-  } catch (error) {
-    setTTSError(error.message || 'Unable to generate auto voice right now.');
-  } finally {
-    if (recorder && recorder.state === 'recording') recorder.stop();
-    if (stream) stream.getTracks().forEach((track) => track.stop());
-    if (audioContext) audioContext.close();
-    setTTSLoadingState(false);
-  }
+  // Reserved for future production TTS integration.
+  showComingSoonTTSNotice();
 }
 
 function createGift(formData) {

--- a/client/upload.html
+++ b/client/upload.html
@@ -75,11 +75,12 @@
               <div class="tts-controls">
                 <label for="ttsVoiceSelect" class="sr-only">Select voice</label>
                 <select id="ttsVoiceSelect" class="tts-voice-select" aria-label="Select auto voice"></select>
-                <button id="generateVoiceBtn" type="button" class="audio-btn tts-generate-btn" aria-label="Generate voice from typed message">
+                <button id="generateVoiceBtn" type="button" class="audio-btn tts-generate-btn is-disabled" aria-label="Generate voice from typed message" disabled title="Coming soon">
                   <span class="tts-pulse" aria-hidden="true"></span>
                   Generate from text
                 </button>
               </div>
+              <p class="tts-helper">Neural voice generation is arriving soon.</p>
               <p id="ttsError" class="audio-error hidden" role="alert"></p>
               <audio id="ttsPreview" class="audio-preview tts-preview hidden" controls preload="metadata" aria-label="Generated voice preview"></audio>
             </section>


### PR DESCRIPTION
### Motivation
- The in-browser TTS capture (speechSynthesis + MediaRecorder + AudioContext) is unreliable across browsers, so the feature is intentionally deferred while preserving recording/upload/QR flows and future extensibility.

### Description
- Update markup in `client/upload.html` to keep `id="generateVoiceBtn"` but add `disabled`, `is-disabled` and `title="Coming soon"`, and add a helper line: "Neural voice generation is arriving soon.".
- Replace active TTS flow by simplifying `generateVoiceFromText()` into an inert, future-ready stub that calls a new `showComingSoonTTSNotice()` helper which shows the toast `"✨ Auto voice generation coming soon"` and exits safely.
- Neutralize unstable runtime logic that attempted to capture `speechSynthesis` output (remove the `AudioContext`/`MediaStreamDestination`/`MediaRecorder` path from the active flow) while preserving voice dropdown population, `ttsPreview`, the `ttsGenerated` flag, and the `audioBlob`/FormData integration exactly as-is.
- Add premium UI polish in `client/css/styles.css` with `.tts-generate-btn.is-disabled` and `.tts-helper` styles and defensive guards in `client/js/upload.js` so clicking the disabled control or missing browser TTS APIs will not throw errors.

### Testing
- Ran `node --check client/js/upload.js` to validate JS syntax and it passed.
- Launched the app with `node server/server.js` and observed the server start message (`Server running on port 5000`).
- Attempted a Playwright UI screenshot run to validate the disabled UI, but the Chromium headless run failed with a SIGSEGV in the environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d53fa5e448329a722b4c2bf2f2932)