### PR TITLE
Fix Multer 'Unexpected field' by accepting optional audio and video uploads

### DIFF
--- a/server/controllers/giftController.js
+++ b/server/controllers/giftController.js
@@ -10,14 +10,20 @@ function buildPublicBaseUrl(req) {
 async function createGift(req, res) {
   try {
     console.log('[gift] body:', req.body);
-    console.log('[gift] file:', req.file?.filename);
+
+    const videoFile = req.files?.video?.[0] || null;
+    const audioFile = req.files?.audio?.[0] || null;
+
+    console.log('[gift] video:', !!videoFile);
+    console.log('[gift] audio:', !!audioFile);
 
     const message = typeof req.body.message === 'string' ? req.body.message.trim() : '';
     if (!message) {
       return res.status(400).json({ error: 'Message is required.' });
     }
 
-    const videoUrl = req.file ? `/uploads/${req.file.filename}` : null;
+    const mediaFile = videoFile || audioFile;
+    const videoUrl = mediaFile ? `/uploads/${mediaFile.filename}` : null;
 
     const gift = new Gift({
       message,

--- a/server/routes/giftRoutes.js
+++ b/server/routes/giftRoutes.js
@@ -30,7 +30,14 @@ const asyncRoute = (handler) => (req, res, next) => {
   });
 };
 
-router.post('/', upload.single('video'), asyncRoute(createGift));
+router.post(
+  '/',
+  upload.fields([
+    { name: 'video', maxCount: 1 },
+    { name: 'audio', maxCount: 1 }
+  ]),
+  asyncRoute(createGift)
+);
 router.get('/:id', asyncRoute(getGift));
 
 module.exports = router;


### PR DESCRIPTION
### Motivation
- Frontend now sends optional `message` text plus optional `video` and `audio` files and the server previously used `upload.single('video')`, which caused `MulterError: Unexpected field` when additional fields arrived. 
- The change must accept both `video` and `audio` without breaking existing video uploads, keep fields optional, and preserve the current API and Railway compatibility.

### Description
- Replaced `upload.single('video')` with `upload.fields([{ name: 'video', maxCount: 1 }, { name: 'audio', maxCount: 1 }])` in `server/routes/giftRoutes.js` to allow both optional fields. 
- Updated `createGift` in `server/controllers/giftController.js` to safely extract files via `const videoFile = req.files?.video?.[0] || null;` and `const audioFile = req.files?.audio?.[0] || null;`. 
- Added defensive logs `console.log('[gift] video:', !!videoFile);` and `console.log('[gift] audio:', !!audioFile);` and preserved backward-compatible storage by using `const mediaFile = videoFile || audioFile;` and `const videoUrl = mediaFile ? "/uploads/${mediaFile.filename}" : null;`. 
- Left message validation, route paths, and existing upload size/limits unchanged to avoid regressions.

### Testing
- Ran syntax checks with `node --check server/routes/giftRoutes.js` which succeeded. 
- Ran syntax checks with `node --check server/controllers/giftController.js` which succeeded. 
- No repository unit tests were present; the change only updates multer wiring and controller extraction to minimize risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d55bd231883299929fa0e396bda40)