### PR TITLE
Fix media upload tab behavior and FormData field mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ Smart QR Gifting lets users create heartfelt digital gifts and share them instan
 - Multilingual ready
 - Voice features (preview)
 
+
+## Supported media uploads
+
+- Text message
+- Video upload
+- Voice recording
+- Image upload
+- GIF upload
+
+Some formats may depend on backend configuration.
+
+
 ## 🔐 Security
 
 The backend is designed with production safety in mind:

--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -38,6 +38,7 @@ let audioStream = null;
 let ttsGenerated = false;
 let ttsVoices = [];
 let ttsIsGenerating = false;
+let activeMediaTab = 'text';
 
 function t(key) {
   return window.smartQRI18n ? window.smartQRI18n.t(key) : key;
@@ -378,11 +379,44 @@ function initTabs() {
       tab.classList.add('active');
       tab.setAttribute('aria-selected', 'true');
 
-      const isVideo = tab.dataset.tab === 'video' || tab.dataset.tab === 'text';
-      const isAudio = tab.dataset.tab === 'audio';
-      futureHint.classList.toggle('hidden', isVideo || isAudio);
-      document.getElementById('video').disabled = tab.dataset.tab !== 'video' && tab.dataset.tab !== 'text';
-      audioRecorderPanel.classList.toggle('hidden', !isAudio);
+      activeMediaTab = tab.dataset.tab;
+      const videoInput = document.getElementById('video');
+
+      const activeTab = tab.dataset.tab;
+
+      // show/hide future hint
+      const isFutureTab = ['image', 'gif'].includes(activeTab);
+      futureHint.classList.toggle('hidden', !isFutureTab);
+
+      // audio panel visibility
+      audioRecorderPanel.classList.toggle('hidden', activeTab !== 'audio');
+
+      // smart file enable logic
+      if (activeTab === 'video' || activeTab === 'text') {
+        videoInput.disabled = false;
+        videoInput.accept = 'video/*';
+      } else if (activeTab === 'image') {
+        videoInput.disabled = false;
+        videoInput.accept = 'image/*';
+      } else if (activeTab === 'gif') {
+        videoInput.disabled = false;
+        videoInput.accept = 'image/gif';
+      } else {
+        videoInput.disabled = true;
+      }
+
+      const fileHint = document.getElementById('fileTypeHint');
+      if (fileHint) {
+        if (activeMediaTab === 'image') {
+          fileHint.textContent = 'Upload JPG, PNG or WEBP image';
+        } else if (activeMediaTab === 'gif') {
+          fileHint.textContent = 'Upload animated GIF';
+        } else if (activeMediaTab === 'video') {
+          fileHint.textContent = 'Upload MP4, WebM, MOV (max 30MB)';
+        } else {
+          fileHint.textContent = '';
+        }
+      }
     });
   });
 }
@@ -402,7 +436,13 @@ uploadForm.addEventListener('submit', async (event) => {
   formData.append('message', message);
 
   if (file) {
-    formData.append('video', file);
+    if (activeMediaTab === 'video' || activeMediaTab === 'text') {
+      formData.append('video', file);
+    } else if (activeMediaTab === 'image') {
+      formData.append('image', file);
+    } else if (activeMediaTab === 'gif') {
+      formData.append('gif', file);
+    }
   }
 
   if (audioBlob) {


### PR DESCRIPTION
### Motivation

- The file chooser was only enabled for `video`/`text` tabs which disabled uploads for `image`, `gif`, and `audio` use cases. 
- Always appending the selected file as `video` caused backend `Unexpected field` errors because Multer validates fields by name. 
- Keep existing IDs, recorder flow and backend contract intact while enabling correct media upload UX.

### Description

- Add `let activeMediaTab = 'text';` to track the currently selected media tab and set it on tab clicks via `activeMediaTab = tab.dataset.tab;`. 
- Replace the previous blunt disable logic with tab-aware behavior that enables/disables the existing `#video` file input and updates its `accept` attribute for `video`, `image`, and `gif` tabs without renaming the element. 
- Update submit handling to append the file to `FormData` using the backend-expected field name based on `activeMediaTab` (`video`, `image`, or `gif`) to prevent `Unexpected field` errors while leaving the `audio` append unchanged. 
- Add optional dynamic helper text updates to `#fileTypeHint` (only applied if the element exists) and add a README section `## Supported media uploads` documenting supported types and a backend dependency note.

### Testing

- `node --check client/js/upload.js` succeeded. 
- `npm start` succeeded and server booted locally. 
- Playwright screenshot attempt failed due to Chromium crash in this environment (SIGSEGV), reported as a failed automated run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d602872f08329a01a0424776db15d)