### PR TITLE
Enable audio file upload in Audio tab while preserving recorder priority

### DIFF
--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -384,17 +384,23 @@ function initTabs() {
 
       const activeTab = tab.dataset.tab;
 
-      // show/hide future hint
-      const isFutureTab = ['image', 'gif'].includes(activeTab);
-      futureHint.classList.toggle('hidden', !isFutureTab);
+      futureHint.classList.toggle(
+        'hidden',
+        !['image', 'gif'].includes(activeTab)
+      );
 
-      // audio panel visibility
-      audioRecorderPanel.classList.toggle('hidden', activeTab !== 'audio');
+      audioRecorderPanel.classList.toggle(
+        'hidden',
+        activeTab !== 'audio'
+      );
 
-      // smart file enable logic
+      // smart accept + enable logic
       if (activeTab === 'video' || activeTab === 'text') {
         videoInput.disabled = false;
         videoInput.accept = 'video/*';
+      } else if (activeTab === 'audio') {
+        videoInput.disabled = false;
+        videoInput.accept = 'audio/*';
       } else if (activeTab === 'image') {
         videoInput.disabled = false;
         videoInput.accept = 'image/*';
@@ -407,7 +413,9 @@ function initTabs() {
 
       const fileHint = document.getElementById('fileTypeHint');
       if (fileHint) {
-        if (activeMediaTab === 'image') {
+        if (activeMediaTab === 'audio') {
+          fileHint.textContent = 'Upload MP3, WAV, or WebM audio — or record live.';
+        } else if (activeMediaTab === 'image') {
           fileHint.textContent = 'Upload JPG, PNG or WEBP image';
         } else if (activeMediaTab === 'gif') {
           fileHint.textContent = 'Upload animated GIF';
@@ -434,10 +442,13 @@ uploadForm.addEventListener('submit', async (event) => {
 
   const formData = new FormData();
   formData.append('message', message);
+  const hasRecordedAudio = Boolean(audioBlob);
 
-  if (file) {
+  if (file && !hasRecordedAudio) {
     if (activeMediaTab === 'video' || activeMediaTab === 'text') {
       formData.append('video', file);
+    } else if (activeMediaTab === 'audio') {
+      formData.append('audio', file);
     } else if (activeMediaTab === 'image') {
       formData.append('image', file);
     } else if (activeMediaTab === 'gif') {


### PR DESCRIPTION
### Motivation
- The Audio tab previously disabled the shared file input which prevented users from uploading audio files while still allowing recording, limiting UX.
- The goal is to support both live recording and uploading audio files without changing backend field names or breaking the existing recorder flow.

### Description
- Updated `initTabs()` in `client/js/upload.js` to enable the shared file input for the Audio tab and set `accept = 'audio/*'`, while keeping the recorder panel visible when Audio is active.
- Added an audio-specific helper hint and preserved existing Text/Video/Image/GIF accept behavior so each tab sets the appropriate `accept` value for the file input.
- Added a `hasRecordedAudio` guard and modified file append logic so uploaded audio is appended via `formData.append('audio', file)` only when no recorded audio exists, and recorded `audioBlob` still takes priority and is appended as before.
- Preserved all existing backend field names and recorder behavior to avoid introducing "Unexpected field" errors.

### Testing
- Ran `node --check client/js/upload.js` to validate JS syntax and it succeeded.
- Launched the local server to smoke-test the app start and it reported the server running on port 5000.
- Attempted an automated Playwright screenshot to verify the Audio tab UI, but the headless Chromium launch failed in this environment (browser process SIGSEGV), so UI screenshot validation did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6a98ca7c832983c67b6aa76971a2)