### PR TITLE
Add premium upload UX: drag & drop, image/GIF/video previews, themes, and lightweight `giftState`

### DIFF
--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -98,6 +98,53 @@ textarea, input[type='file'] {
 }
 textarea { min-height: 120px; resize: vertical; }
 
+.drop-zone {
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  padding: 0.45rem;
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  transition: border-color 160ms ease, background-color 160ms ease, box-shadow 160ms ease;
+}
+
+.drop-zone.drag-over {
+  border-color: color-mix(in srgb, var(--primary) 70%, #fff);
+  background: color-mix(in srgb, var(--primary) 10%, var(--surface));
+  box-shadow: 0 0 0 3px var(--ring);
+}
+
+.file-preview {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.65rem;
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+}
+
+.file-preview img,
+.file-preview video {
+  width: 100%;
+  max-height: 260px;
+  object-fit: contain;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, #000 18%, var(--surface));
+}
+
+.theme-picker {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.theme-picker select {
+  width: 100%;
+  min-height: 44px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  color: var(--text);
+  font: inherit;
+  padding: 0.7rem 0.75rem;
+}
+
 button, .button-link {
   display: inline-flex; justify-content: center; align-items: center; gap: 0.45rem;
   border: 0; border-radius: 12px; padding: 0.8rem 1rem; font: inherit; font-weight: 700; cursor: pointer;

--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -40,8 +40,117 @@ let ttsVoices = [];
 let ttsIsGenerating = false;
 let activeMediaTab = 'text';
 
+const giftState = {
+  activeTab: 'text',
+  uploadedFile: null,
+  recordedAudio: null,
+  previewUrl: '',
+  theme: 'default',
+  encryptionEnabled: true
+};
+
 function t(key) {
   return window.smartQRI18n ? window.smartQRI18n.t(key) : key;
+}
+
+function setActiveTab(tab) {
+  giftState.activeTab = tab;
+}
+
+function setUploadedFile(file) {
+  giftState.uploadedFile = file;
+}
+
+function setRecordedAudio(blob) {
+  giftState.recordedAudio = blob;
+}
+
+function clearPreview() {
+  if (giftState.previewUrl) {
+    URL.revokeObjectURL(giftState.previewUrl);
+  }
+  giftState.previewUrl = '';
+
+  const wrap = document.getElementById('filePreviewWrap');
+  const img = document.getElementById('imagePreview');
+  const video = document.getElementById('videoPreview');
+
+  if (img) {
+    img.removeAttribute('src');
+    img.classList.add('hidden');
+  }
+
+  if (video) {
+    video.pause();
+    video.removeAttribute('src');
+    video.load();
+    video.classList.add('hidden');
+  }
+
+  if (wrap) {
+    wrap.classList.add('hidden');
+  }
+}
+
+function handleFilePreview(file) {
+  if (!file) {
+    clearPreview();
+    return;
+  }
+
+  const wrap = document.getElementById('filePreviewWrap');
+  const img = document.getElementById('imagePreview');
+  const video = document.getElementById('videoPreview');
+  if (!wrap || !img || !video) return;
+
+  wrap.classList.remove('hidden');
+
+  img.classList.add('hidden');
+  video.classList.add('hidden');
+
+  if (giftState.previewUrl) {
+    URL.revokeObjectURL(giftState.previewUrl);
+  }
+
+  const url = URL.createObjectURL(file);
+  giftState.previewUrl = url;
+
+  if (file.type.startsWith('image/')) {
+    img.src = url;
+    img.classList.remove('hidden');
+  } else if (file.type.startsWith('video/')) {
+    video.src = url;
+    video.classList.remove('hidden');
+  }
+}
+
+function initDragDrop() {
+  const dropZone = document.getElementById('dropZone');
+  const videoInput = document.getElementById('video');
+  if (!dropZone || !videoInput) return;
+
+  ['dragenter', 'dragover'].forEach((eventName) => {
+    dropZone.addEventListener(eventName, (e) => {
+      e.preventDefault();
+      dropZone.classList.add('drag-over');
+    });
+  });
+
+  ['dragleave', 'drop'].forEach((eventName) => {
+    dropZone.addEventListener(eventName, () => {
+      dropZone.classList.remove('drag-over');
+    });
+  });
+
+  dropZone.addEventListener('drop', (e) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (!file) return;
+
+    videoInput.files = e.dataTransfer.files;
+    setUploadedFile(file);
+    handleFilePreview(file);
+  });
 }
 
 function setStatus(message, isError = false, isLoading = false) {
@@ -126,6 +235,7 @@ function setTTSLoadingState(isLoading) {
 
 function setGeneratedAudioBlob(blob, source = 'recording') {
   audioBlob = blob;
+  setRecordedAudio(blob);
   ttsGenerated = source === 'tts';
   if (source === 'recording') {
     clearTTSAudioPreview();
@@ -380,6 +490,7 @@ function initTabs() {
       tab.setAttribute('aria-selected', 'true');
 
       activeMediaTab = tab.dataset.tab;
+      setActiveTab(tab.dataset.tab);
       const videoInput = document.getElementById('video');
 
       const activeTab = tab.dataset.tab;
@@ -429,11 +540,28 @@ function initTabs() {
   });
 }
 
+const themeSelect = document.getElementById('themeSelect');
+
+if (themeSelect) {
+  themeSelect.addEventListener('change', (e) => {
+    giftState.theme = e.target.value;
+  });
+}
+
+const videoInput = document.getElementById('video');
+if (videoInput) {
+  videoInput.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    setUploadedFile(file || null);
+    handleFilePreview(file);
+  });
+}
+
 uploadForm.addEventListener('submit', async (event) => {
   event.preventDefault();
 
   const message = document.getElementById('message').value.trim();
-  const file = document.getElementById('video').files[0];
+  const file = giftState.uploadedFile || document.getElementById('video').files[0];
 
   if (!message) {
     setStatus(t('upload.statusMissingMessage'), true);
@@ -465,6 +593,9 @@ uploadForm.addEventListener('submit', async (event) => {
   setStatus(t('upload.statusLoading'), false, true);
   resultEl.classList.add('hidden');
   resultEl.classList.remove('success');
+
+  formData.append('encrypted', 'true');
+  formData.append('theme', giftState.theme);
 
   try {
     const data = await createGift(formData);
@@ -533,3 +664,10 @@ document.addEventListener('smartqr:languagechange', () => {
 
 initTabs();
 initAudioRecorder();
+initDragDrop();
+
+window.addEventListener('beforeunload', () => {
+  clearPreview();
+  clearAudioPreview();
+  clearTTSAudioPreview();
+});

--- a/client/upload.html
+++ b/client/upload.html
@@ -46,7 +46,14 @@
           <textarea id="message" maxlength="300" data-i18n-placeholder="upload.messagePlaceholder" required></textarea>
 
           <label for="video" data-i18n="upload.videoLabel"></label>
-          <input type="file" id="video" accept="video/mp4,video/webm,video/ogg,video/quicktime" />
+          <div id="dropZone" class="drop-zone">
+            <input type="file" id="video" accept="video/mp4,video/webm,video/ogg,video/quicktime" />
+          </div>
+
+          <div id="filePreviewWrap" class="file-preview hidden">
+            <img id="imagePreview" class="hidden" alt="Uploaded file preview" />
+            <video id="videoPreview" class="hidden" controls preload="metadata"></video>
+          </div>
 
           <section id="audioRecorderPanel" class="audio-recorder hidden" aria-live="polite" data-audio-recorder="true">
             <div class="audio-recorder-head">
@@ -89,6 +96,16 @@
           <div id="uploadProgressWrap" class="progress-wrap hidden" aria-live="polite">
             <div class="progress-bar"><span id="uploadProgressBar"></span></div>
             <small id="uploadProgressText">0%</small>
+          </div>
+
+          <div class="theme-picker">
+            <label for="themeSelect">Gift Theme</label>
+            <select id="themeSelect">
+              <option value="default">Default</option>
+              <option value="birthday">Birthday</option>
+              <option value="romantic">Romantic</option>
+              <option value="corporate">Corporate</option>
+            </select>
           </div>
 
           <button id="submitBtn" type="submit" data-i18n="upload.submit"></button>


### PR DESCRIPTION
### Motivation
- Introduce a production-grade premium UX layer for uploads (previews, drag/drop, theme selection, and encrypted link payload prep) while preserving all existing uploader and recorder behavior. 
- Provide a small, framework-free frontend state store to keep UI and form payloads consistent across tabs and interactions.

### Description
- Added a lightweight global state object `giftState` in `client/js/upload.js` and helper setters `setActiveTab`, `setUploadedFile`, `setRecordedAudio`, and `clearPreview` to track tab, file, preview URL, theme, and encryption flag. 
- Implemented image/GIF/video preview rendering with proper object-URL lifecycle cleanup and hooked it into the existing file input via a new `handleFilePreview` and `change` listener. 
- Wrapped the existing file input with a `#dropZone` and added `initDragDrop()` to support drag & drop uploads that reuse the same file input and preview/state logic. 
- Added a `theme` selector UI in `client/upload.html` and JS hookup that appends `theme` and `encrypted=true` to the `FormData` payload before calling `createGift()`; existing media FormData keys and API request remain unchanged. 
- Added minimal CSS for `.drop-zone`, `.file-preview`, and `.theme-picker` to `client/css/styles.css`, keeping layout and mobile responsiveness intact.

### Testing
- Ran `node --check client/js/upload.js` and it passed with no syntax errors. 
- Ran `node --check server.js` and it passed with no syntax errors. 
- Started the app with `npm start` and observed the server boot message indicating the server is running. 
- Attempted an automated browser smoke (Playwright) to exercise the preview and theme selection, but the headless browser process crashed in this environment (SIGSEGV) so no screenshot artifact was produced; all other automated checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6cdd987483299b7caa754aaa16d8)