### PR TITLE
Add multilingual safety, client-side image compression, and cinematic reveal UI

### DIFF
--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -382,3 +382,46 @@ button:focus-visible, .button-link:focus-visible, textarea:focus-visible, input:
   .audio-actions .audio-btn { width: 100%; }
   .tts-controls > * { width: 100%; }
 }
+
+body[data-gift-theme="birthday"] {
+  background:
+    radial-gradient(circle at 20% 20%, #ff7bd5 0%, transparent 40%),
+    radial-gradient(circle at 80% 30%, #7b9cff 0%, transparent 40%),
+    #0b1020;
+}
+
+body[data-gift-theme="romantic"] {
+  background:
+    radial-gradient(circle at 50% 20%, #ff4d6d 0%, transparent 45%),
+    #0b1020;
+}
+
+body[data-gift-theme="corporate"] {
+  background:
+    linear-gradient(135deg, #0f172a, #111827);
+}
+
+.gift-reveal {
+  opacity: 0;
+  transform: scale(0.96) translateY(20px);
+  transition: all 600ms cubic-bezier(.21,1.02,.73,1);
+}
+
+.gift-reveal.reveal-active {
+  opacity: 1;
+  transform: scale(1) translateY(0);
+}
+
+.gift-success-title {
+  margin-bottom: 0.9rem;
+}
+
+.success-pulse {
+  animation: successGlow 900ms ease-out;
+}
+
+@keyframes successGlow {
+  0% { filter: brightness(1); }
+  50% { filter: brightness(1.15); }
+  100% { filter: brightness(1); }
+}

--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -445,6 +445,45 @@ async function generateVoiceFromText() {
   showComingSoonTTSNotice();
 }
 
+async function compressImageIfNeeded(file) {
+  if (!file || !file.type.startsWith('image/')) return file;
+
+  if (file.size < 800 * 1024) return file;
+
+  const bitmap = await createImageBitmap(file);
+  const canvas = document.createElement('canvas');
+
+  const MAX_WIDTH = 1280;
+  const scale = Math.min(1, MAX_WIDTH / bitmap.width);
+
+  canvas.width = bitmap.width * scale;
+  canvas.height = bitmap.height * scale;
+
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+
+  return new Promise((resolve) => {
+    canvas.toBlob(
+      (blob) => resolve(blob || file),
+      'image/jpeg',
+      0.82
+    );
+  });
+}
+
+function normalizeMessage(text) {
+  return text
+    .normalize('NFC')
+    .trim();
+}
+
+function softCelebrationPulse() {
+  document.body.classList.add('success-pulse');
+  setTimeout(() => {
+    document.body.classList.remove('success-pulse');
+  }, 900);
+}
+
 function createGift(formData) {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
@@ -560,27 +599,52 @@ if (videoInput) {
 uploadForm.addEventListener('submit', async (event) => {
   event.preventDefault();
 
-  const message = document.getElementById('message').value.trim();
+  const message = document.getElementById('message').value;
   const file = giftState.uploadedFile || document.getElementById('video').files[0];
 
-  if (!message) {
+  if (!normalizeMessage(message)) {
     setStatus(t('upload.statusMissingMessage'), true);
     return;
   }
 
   const formData = new FormData();
-  formData.append('message', message);
+  const normalizedMessage = normalizeMessage(message);
+  formData.append('message', normalizedMessage);
   const hasRecordedAudio = Boolean(audioBlob);
 
   if (file && !hasRecordedAudio) {
     if (activeMediaTab === 'video' || activeMediaTab === 'text') {
-      formData.append('video', file);
+      let processedFile = file;
+
+      if (file.type.startsWith('image/')) {
+        processedFile = await compressImageIfNeeded(file);
+      }
+
+      if (processedFile) {
+        formData.append('video', processedFile, file.name);
+      }
     } else if (activeMediaTab === 'audio') {
       formData.append('audio', file);
     } else if (activeMediaTab === 'image') {
-      formData.append('image', file);
+      let processedFile = file;
+
+      if (file.type.startsWith('image/')) {
+        processedFile = await compressImageIfNeeded(file);
+      }
+
+      if (processedFile) {
+        formData.append('image', processedFile, file.name);
+      }
     } else if (activeMediaTab === 'gif') {
-      formData.append('gif', file);
+      let processedFile = file;
+
+      if (file.type.startsWith('image/')) {
+        processedFile = await compressImageIfNeeded(file);
+      }
+
+      if (processedFile) {
+        formData.append('gif', processedFile, file.name);
+      }
     }
   }
 
@@ -613,9 +677,20 @@ uploadForm.addEventListener('submit', async (event) => {
     openLinkEl.rel = 'noopener noreferrer';
 
     resultEl.classList.remove('hidden');
+    document.body.dataset.giftTheme = giftState.theme || 'default';
+    const reveal = document.getElementById('giftReveal');
+    if (reveal) {
+      reveal.classList.remove('reveal-active');
+    }
     requestAnimationFrame(() => {
       resultEl.classList.add('success');
       launchSuccessBurst();
+      softCelebrationPulse();
+      if (reveal) {
+        requestAnimationFrame(() => {
+          reveal.classList.add('reveal-active');
+        });
+      }
     });
 
     setStatus(t('upload.statusSuccess'));

--- a/client/upload.html
+++ b/client/upload.html
@@ -43,7 +43,7 @@
 
         <form id="uploadForm" class="gift-form" novalidate>
           <label for="message" data-i18n="upload.messageLabel"></label>
-          <textarea id="message" maxlength="300" data-i18n-placeholder="upload.messagePlaceholder" required></textarea>
+          <textarea id="message" maxlength="2000" data-i18n-placeholder="upload.messagePlaceholder" required></textarea>
 
           <label for="video" data-i18n="upload.videoLabel"></label>
           <div id="dropZone" class="drop-zone">
@@ -114,13 +114,16 @@
         <p id="status" class="status" aria-live="polite"></p>
 
         <section id="result" class="result hidden" aria-live="polite">
-          <h2 data-i18n="upload.resultTitle"></h2>
-          <img id="qrImage" alt="Gift QR code" />
-          <a id="openLink" class="button-link" target="_blank" rel="noopener noreferrer" data-i18n="upload.openGift"></a>
-          <div class="action-row">
-            <button id="copyLinkBtn" class="button-link button-secondary" type="button" data-i18n="upload.copyLink"></button>
-            <button id="shareBtn" class="button-link button-secondary" type="button" data-i18n="upload.share"></button>
-            <button id="downloadQrBtn" class="button-link button-secondary" type="button" data-i18n="upload.downloadQr"></button>
+          <div id="giftReveal" class="gift-reveal">
+            <h2 data-i18n="upload.resultTitle"></h2>
+            <h3 class="gift-success-title">✨ Your Smart Gift is Ready!</h3>
+            <img id="qrImage" alt="Gift QR code" />
+            <a id="openLink" class="button-link" target="_blank" rel="noopener noreferrer" data-i18n="upload.openGift"></a>
+            <div class="action-row">
+              <button id="copyLinkBtn" class="button-link button-secondary" type="button" data-i18n="upload.copyLink"></button>
+              <button id="shareBtn" class="button-link button-secondary" type="button" data-i18n="upload.share"></button>
+              <button id="downloadQrBtn" class="button-link button-secondary" type="button" data-i18n="upload.downloadQr"></button>
+            </div>
           </div>
           <div id="successConfetti" class="success-burst" aria-hidden="true"></div>
         </section>


### PR DESCRIPTION
### Motivation
- Ensure the upload flow accepts any language and Unicode input safely (including Hindi, Arabic, Japanese, emojis) and normalize message text before sending. 
- Reduce upload friction and give a premium feel by compressing large images client-side before upload. 
- Elevate the success moment with a cinematic reveal and theme-aware result background while keeping all existing behavior and API fields intact.

### Description
- Increased message capacity and relaxed frontend limits by changing the textarea `maxlength` to `2000` and kept `UTF-8` meta in place. (`client/upload.html`)
- Added `normalizeMessage(text)` and applied it in the submit flow so the appended `message` is NFC-normalized and trimmed before `formData.append('message', ...)`. (`client/js/upload.js`)
- Implemented `compressImageIfNeeded(file)` and integrated it into the submit flow to smartly compress large image files; preserved backend field names (`video`, `image`, `gif`, `audio`) and filename when appending processed files. (`client/js/upload.js`)
- Introduced a reveal wrapper `#giftReveal`, a `.gift-reveal` animation, a success headline, and a `softCelebrationPulse()` effect; set `document.body.dataset.giftTheme = giftState.theme || 'default'` on success and added theme styles for `birthday`, `romantic`, and `corporate`. (`client/upload.html`, `client/css/styles.css`, `client/js/upload.js`)
- Preserved existing state, drag/drop, audio recording, tab logic, and API contract (`message`, `video`, `image`, `gif`, `audio`, `theme`, `encrypted`).

### Testing
- Ran static checks with `node --check client/js/upload.js` and `node --check server.js`, both completed without errors. 
- Rendered upload success state in a headless browser and captured a screenshot to validate the reveal animation and theme application (artifact: `artifacts/premium-upload-result.png`).
- Verified code changes/searches with `rg` to confirm `maxlength`, `normalizeMessage`, `compressImageIfNeeded`, `giftReveal`, and `dataset.giftTheme` are present and wired as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6fb1cb008329b608d785611a1728)