### PR TITLE
Immersive, theme-driven gift result experience

### DIFF
--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -712,3 +712,183 @@ body.theme-birthday .gift-spotlight { animation: spotlightFloat 8s ease-in-out i
   .viewer-card { margin-top: 1rem; }
   .gift-spotlight { padding: 1rem; }
 }
+
+/* Immersive result experience */
+body.viewer-experience {
+  overflow-x: clip;
+  --gift-theme-gradient: linear-gradient(135deg, #1f153f 0%, #3e2972 48%, #5640a8 100%);
+  --gift-theme-glow: rgba(156, 125, 255, 0.24);
+}
+
+.theme-immersive-bg {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+}
+
+.theme-immersive-bg__gradient,
+.theme-immersive-bg__glow,
+.view-particles,
+.gift-spotlight,
+.gift-message {
+  opacity: 0;
+}
+
+.theme-immersive-bg__gradient,
+.theme-immersive-bg__glow {
+  position: absolute;
+  inset: 0;
+  will-change: transform, opacity, filter;
+}
+
+.theme-immersive-bg__gradient {
+  background-image: var(--gift-theme-gradient);
+  background-size: 170% 170%;
+  animation: themeGradientShift 18s ease-in-out infinite;
+}
+
+.theme-immersive-bg__glow {
+  background: radial-gradient(circle at 20% 22%, var(--gift-theme-glow), transparent 58%);
+  filter: blur(18px);
+}
+
+body.experience-bg-visible .theme-immersive-bg__gradient,
+body.experience-bg-visible .theme-immersive-bg__glow {
+  opacity: 1;
+  transition: opacity 900ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+body.experience-particles-visible .view-particles {
+  opacity: 1;
+  transition: opacity 800ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.gift-spotlight {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.22) 70%, transparent);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border: 1px solid color-mix(in srgb, var(--gift-theme-primary) 55%, rgba(255, 255, 255, 0.55));
+  box-shadow: 0 20px 70px color-mix(in srgb, var(--gift-theme-primary) 28%, transparent);
+  transform: translate3d(0, 22px, 0) scale(0.96);
+  will-change: transform, opacity;
+  animation: spotlightFloat 7.2s ease-in-out infinite;
+}
+
+body.experience-card-visible .gift-spotlight {
+  opacity: 1;
+  transform: translate3d(0, 0, 0) scale(1);
+  transition: transform 1s cubic-bezier(0.22, 1, 0.36, 1), opacity 700ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.gift-message {
+  transform: translate3d(0, 12px, 0);
+  will-change: transform, opacity;
+}
+
+body.experience-message-visible .gift-message {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+  transition: transform 780ms cubic-bezier(0.22, 1, 0.36, 1), opacity 620ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.view-particles {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+}
+
+.view-particles__dot {
+  position: absolute;
+  bottom: -12vh;
+  width: 8px;
+  height: 8px;
+  will-change: transform, opacity, filter;
+  animation: particleDrift var(--gift-animation-speed, 18s) ease-in-out infinite;
+}
+
+@keyframes particleDrift {
+  0% { transform: translate3d(0, 0, 0); opacity: 0; }
+  20% { opacity: 0.8; }
+  50% { transform: translate3d(var(--particle-sway, 10px), -52vh, 0); }
+  100% { transform: translate3d(calc(var(--particle-sway, 10px) * -0.5), -110vh, 0); opacity: 0; }
+}
+
+.particles-confetti .view-particles__dot {
+  border-radius: 2px;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--gift-theme-secondary) 75%, #fff), var(--gift-theme-primary));
+}
+.particles-sparkle .view-particles__dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #f7ecd1;
+  box-shadow: 0 0 12px rgba(247, 236, 209, 0.6);
+  animation-name: sparkleDrift;
+}
+@keyframes sparkleDrift {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(0.7); opacity: 0; }
+  35% { opacity: 0.9; }
+  50% { transform: translate3d(var(--particle-sway, 8px), -48vh, 0) scale(1); opacity: 0.6; }
+}
+.particles-hearts .view-particles__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px 3px 10px 10px;
+  background: color-mix(in srgb, var(--gift-theme-primary) 68%, #fff);
+  filter: blur(0.5px);
+  transform: rotate(45deg);
+}
+.particles-dots .view-particles__dot {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--gift-theme-secondary) 70%, var(--gift-theme-primary));
+}
+.particles-glow-pulse .view-particles__dot {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--gift-theme-primary) 60%, #fff);
+  filter: blur(1px);
+  animation-name: glowPulseDrift;
+}
+@keyframes glowPulseDrift {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(0.7); opacity: 0; }
+  45% { transform: translate3d(var(--particle-sway, 12px), -52vh, 0) scale(1.15); opacity: 0.75; }
+}
+
+body.theme-corporate .view-particles {
+  opacity: 0 !important;
+}
+body.theme-corporate .gift-spotlight::after {
+  content: '';
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  top: 28%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(154, 184, 223, 0.7), transparent);
+  animation: lineSweep 8.5s ease-in-out infinite;
+}
+
+@media (max-width: 479px) {
+  .theme-immersive-bg__glow {
+    filter: blur(12px);
+    opacity: 0.72;
+  }
+  .gift-spotlight {
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 14px 42px color-mix(in srgb, var(--gift-theme-primary) 22%, transparent);
+  }
+}
+.theme-preview[data-theme="wedding"] .theme-preview__card {
+  background: linear-gradient(135deg, #d4af37, #8f6c29);
+}
+.theme-preview[data-theme="corporate"] .theme-preview__card {
+  background: linear-gradient(135deg, #1f3f77, #4568a0);
+}
+.theme-preview[data-theme="surprise"] .theme-preview__card {
+  background: linear-gradient(135deg, #7c3aed, #4c1d95);
+}

--- a/client/js/upload.js
+++ b/client/js/upload.js
@@ -648,8 +648,9 @@ function initTabs() {
 }
 
 function normalizeTheme(theme) {
-  if (theme === 'romantic') return 'love';
-  if (theme === 'corporate') return 'festival';
+  if (window.resolveGiftTheme) {
+    return window.resolveGiftTheme(theme);
+  }
   return theme || 'default';
 }
 
@@ -771,7 +772,7 @@ uploadForm.addEventListener('submit', async (event) => {
     openLinkEl.rel = 'noopener noreferrer';
 
     resultEl.classList.remove('hidden');
-    document.body.dataset.giftTheme = giftState.theme || 'default';
+    document.body.dataset.giftTheme = normalizeTheme(giftState.theme);
     const reveal = document.getElementById('giftReveal');
     if (reveal) {
       reveal.classList.remove('reveal-active');

--- a/client/js/view.js
+++ b/client/js/view.js
@@ -13,55 +13,97 @@ function setStatus(message, isError = false) {
   statusEl.classList.toggle('error', isError);
 }
 
-function sanitizeTheme(theme) {
-  const normalized = (theme || 'default').toLowerCase();
-  const aliases = {
-    love: 'wedding',
-    romantic: 'wedding',
-    festival: 'corporate'
+function getTheme(themeName) {
+  const resolved = window.resolveGiftTheme ? window.resolveGiftTheme(themeName) : 'default';
+  return {
+    name: resolved,
+    config: THEME_CONFIG[resolved] || THEME_CONFIG.default
   };
-  const resolved = aliases[normalized] || normalized;
-  return THEME_CONFIG[resolved] ? resolved : 'default';
 }
 
-function applyThemeExperience(theme) {
-  const normalizedTheme = sanitizeTheme(theme);
-  const themeToken = THEME_CONFIG[normalizedTheme];
+function createBackgroundLayer() {
+  const existing = document.querySelector('.theme-immersive-bg');
+  if (existing) return existing;
 
-  document.body.classList.remove(
-    'theme-birthday',
-    'theme-wedding',
-    'theme-corporate',
-    'theme-surprise',
-    'theme-default'
-  );
-  document.body.classList.add(`theme-${normalizedTheme}`);
-  document.body.dataset.giftTheme = normalizedTheme;
-  document.body.style.setProperty('--gift-theme-primary', themeToken.primary);
-  document.body.style.setProperty('--gift-theme-secondary', themeToken.secondary);
+  const background = document.createElement('div');
+  background.className = 'theme-immersive-bg';
+  background.innerHTML = `
+    <div class="theme-immersive-bg__gradient"></div>
+    <div class="theme-immersive-bg__glow"></div>
+  `;
+  document.body.prepend(background);
+  return background;
+}
 
-  if (spotlightEl) {
-    spotlightEl.dataset.mood = themeToken.mood;
-  }
-
+function createParticles(themeName, themeToken) {
   const existingLayer = document.querySelector('.view-particles');
   if (existingLayer) {
     existingLayer.remove();
   }
 
+  if (!themeToken.animationSpeed) {
+    return;
+  }
+
   const layer = document.createElement('div');
-  layer.className = `view-particles particles-${themeToken.particles}`;
+  layer.className = `view-particles particles-${themeToken.particleStyle} particles-${themeName}`;
   document.body.appendChild(layer);
 
-  const particleCount = themeToken.particles === 'minimal' ? 8 : 14;
+  const isMobile = window.matchMedia('(max-width: 479px)').matches;
+  const baseCount = {
+    confetti: 14,
+    sparkle: 10,
+    hearts: 10,
+    dots: 12,
+    'glow-pulse': 9,
+    'line-shimmer': 4,
+    minimal: 0
+  }[themeToken.particleStyle] || 8;
+
+  const particleCount = isMobile ? Math.max(4, Math.ceil(baseCount / 2)) : baseCount;
+
   for (let i = 0; i < particleCount; i += 1) {
-    const dot = document.createElement('span');
-    dot.className = 'view-particles__dot';
-    dot.style.left = `${Math.random() * 100}%`;
-    dot.style.animationDelay = `${Math.random() * 4}s`;
-    dot.style.animationDuration = `${6 + Math.random() * 4}s`;
-    layer.appendChild(dot);
+    const particle = document.createElement('span');
+    particle.className = 'view-particles__dot';
+    particle.style.left = `${Math.random() * 100}%`;
+    particle.style.animationDelay = `${Math.random() * themeToken.animationSpeed}s`;
+    particle.style.animationDuration = `${themeToken.animationSpeed + (Math.random() * 4 - 2)}s`;
+    particle.style.setProperty('--particle-sway', `${(Math.random() * 24 - 12).toFixed(1)}px`);
+    layer.appendChild(particle);
   }
+}
+
+function runEntrySequence() {
+  document.body.classList.remove('experience-bg-visible', 'experience-particles-visible', 'experience-card-visible', 'experience-message-visible');
+
+  window.setTimeout(() => document.body.classList.add('experience-bg-visible'), 0);
+  window.setTimeout(() => document.body.classList.add('experience-particles-visible'), 200);
+  window.setTimeout(() => document.body.classList.add('experience-card-visible'), 400);
+  window.setTimeout(() => document.body.classList.add('experience-message-visible'), 600);
+}
+
+function applyThemeExperience(theme) {
+  const { name, config } = getTheme(theme);
+
+  document.body.classList.add('viewer-experience');
+  document.body.classList.remove(...(window.GIFT_THEME_CLASS_LIST || []));
+  document.body.classList.add(`theme-${name}`);
+  document.body.dataset.giftTheme = name;
+
+  document.body.style.setProperty('--gift-theme-primary', config.primary);
+  document.body.style.setProperty('--gift-theme-secondary', config.secondary);
+  document.body.style.setProperty('--gift-theme-gradient', config.gradient);
+  document.body.style.setProperty('--gift-theme-glow', config.glowColor);
+  document.body.style.setProperty('--gift-animation-speed', `${config.animationSpeed}s`);
+
+  createBackgroundLayer();
+  createParticles(name, config);
+
+  if (spotlightEl) {
+    spotlightEl.dataset.theme = name;
+  }
+
+  runEntrySequence();
 }
 
 function resolveMediaUrl(videoUrl) {

--- a/client/upload.html
+++ b/client/upload.html
@@ -104,10 +104,11 @@
             <select id="themeSelect">
               <option value="default">Default</option>
               <option value="birthday">Birthday</option>
+              <option value="wedding">Wedding</option>
+              <option value="corporate gifting">Corporate</option>
               <option value="love">Love</option>
               <option value="festival">Festival</option>
-              <option value="romantic">Romantic</option>
-              <option value="corporate">Corporate</option>
+              <option value="surprise">Surprise</option>
             </select>
           </div>
 
@@ -145,6 +146,7 @@
   <script src="js/i18n.js"></script>
   <script src="js/app-shell.js"></script>
   <script src="js/config.js"></script>
+  <script src="utils/themeResolver.js"></script>
   <script src="js/upload.js"></script>
 </body>
 </html>

--- a/client/utils/themeConfig.js
+++ b/client/utils/themeConfig.js
@@ -1,38 +1,59 @@
 export const THEME_CONFIG = {
   birthday: {
-    primary: "#ff7b7b",
-    secondary: "#ffd6a5",
-    background: "birthday-gradient",
-    particles: "confetti",
-    mood: "celebration"
+    primary: '#ff7b7b',
+    secondary: '#ffd6a5',
+    gradient: 'linear-gradient(135deg, #2f1639 0%, #613457 48%, #a95d47 100%)',
+    particleStyle: 'confetti',
+    animationSpeed: 18,
+    glowColor: 'rgba(255, 169, 107, 0.45)'
   },
   wedding: {
-    primary: "#e6c200",
-    secondary: "#fff4d6",
-    background: "wedding-gradient",
-    particles: "sparkle",
-    mood: "romantic"
+    primary: '#d4af37',
+    secondary: '#f7ecd1',
+    gradient: 'linear-gradient(135deg, #21160d 0%, #493520 52%, #7c5f34 100%)',
+    particleStyle: 'sparkle',
+    animationSpeed: 22,
+    glowColor: 'rgba(248, 226, 167, 0.38)'
   },
   corporate: {
-    primary: "#1e3a8a",
-    secondary: "#93c5fd",
-    background: "corporate-gradient",
-    particles: "minimal",
-    mood: "professional"
+    primary: '#1f3f77',
+    secondary: '#9ab8df',
+    gradient: 'linear-gradient(135deg, #0c1b34 0%, #14315a 50%, #20466f 100%)',
+    particleStyle: 'line-shimmer',
+    animationSpeed: 0,
+    glowColor: 'rgba(120, 166, 214, 0.22)'
+  },
+  love: {
+    primary: '#f0548a',
+    secondary: '#ffc2d8',
+    gradient: 'linear-gradient(135deg, #2a1025 0%, #5d1f42 52%, #8a305f 100%)',
+    particleStyle: 'hearts',
+    animationSpeed: 20,
+    glowColor: 'rgba(255, 140, 176, 0.36)'
+  },
+  festival: {
+    primary: '#9b5de5',
+    secondary: '#f9c74f',
+    gradient: 'linear-gradient(135deg, #161637 0%, #353d7b 48%, #844cb1 100%)',
+    particleStyle: 'dots',
+    animationSpeed: 16,
+    glowColor: 'rgba(255, 211, 107, 0.34)'
   },
   surprise: {
-    primary: "#7c3aed",
-    secondary: "#c4b5fd",
-    background: "surprise-gradient",
-    particles: "burst",
-    mood: "mystery"
+    primary: '#7c3aed',
+    secondary: '#c4b5fd',
+    gradient: 'linear-gradient(135deg, #170f37 0%, #322069 48%, #513099 100%)',
+    particleStyle: 'glow-pulse',
+    animationSpeed: 14,
+    glowColor: 'rgba(166, 133, 255, 0.4)'
   },
   default: {
-    primary: "#8b5cf6",
-    secondary: "#c4b5fd",
-    background: "default-gradient",
-    particles: "minimal",
-    mood: "clean"
+    primary: '#8b5cf6',
+    secondary: '#c4b5fd',
+    gradient: 'linear-gradient(135deg, #1f153f 0%, #3e2972 48%, #5640a8 100%)',
+    particleStyle: 'minimal',
+    animationSpeed: 0,
+    glowColor: 'rgba(156, 125, 255, 0.24)'
   }
 };
 

--- a/client/utils/themeResolver.js
+++ b/client/utils/themeResolver.js
@@ -1,0 +1,32 @@
+const THEME_CLASS_LIST = [
+  'theme-birthday',
+  'theme-wedding',
+  'theme-corporate',
+  'theme-love',
+  'theme-festival',
+  'theme-surprise',
+  'theme-default'
+];
+
+function resolveTheme(category) {
+  const normalized = (category || 'default').toString().trim().toLowerCase();
+
+  const mapping = {
+    birthday: 'birthday',
+    wedding: 'wedding',
+    'corporate gifting': 'corporate',
+    corporate: 'corporate',
+    love: 'love',
+    romantic: 'love',
+    festival: 'festival',
+    surprise: 'surprise',
+    default: 'default'
+  };
+
+  return mapping[normalized] || 'default';
+}
+
+if (typeof window !== 'undefined') {
+  window.resolveGiftTheme = resolveTheme;
+  window.GIFT_THEME_CLASS_LIST = THEME_CLASS_LIST;
+}

--- a/client/view.html
+++ b/client/view.html
@@ -16,10 +16,11 @@
         <video id="videoPlayer" class="gift-video hidden" controls playsinline preload="metadata"></video>
         <p id="giftMessage" class="gift-message"></p>
       </div>
-      <!-- FUTURE AR: media will be projected into real-world surface -->
+      <!-- // FUTURE AR SURFACE ANCHOR -->
     </section>
   </main>
   <script src="js/config.js"></script>
+  <script src="utils/themeResolver.js"></script>
   <script type="module" src="js/view.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Make the gift result page emotionally immersive, theme-driven and premium while preserving existing gift loading and keeping performance/mobile-smoothness top priority. 
- Slow down/standardize particle/confetti motion and clearly differentiate categories (birthday, wedding, corporate, love, festival, surprise, default). 

### Description
- Expanded theme tokens in `client/utils/themeConfig.js` to include `primary`, `secondary`, `gradient`, `particleStyle`, `animationSpeed`, and `glowColor` for `birthday`, `wedding`, `corporate`, `love`, `festival`, `surprise`, and `default`, and set the required animation durations (including `0` for corporate/default). 
- Added a centralized category → theme helper in `client/utils/themeResolver.js` (maps `corporate gifting -> corporate`, `romantic -> love`, fallback to `default`) and expose it via `window.resolveGiftTheme`. 
- Reworked viewer logic in `client/js/view.js` to: resolve themes via the new resolver, inject layered background nodes (animated gradient + radial glow), create lightweight CSS particle fields driven by `theme.animationSpeed` (disabled when `0`), reduce particle counts on small screens, and run a staggered entry sequence (`0ms/200ms/400ms/600ms`) with the requested easing. 
- Upgraded result visuals in `client/css/styles.css` with a glassmorphism `gift-spotlight` (backdrop blur, soft theme glow border, slow float), theme-driven gradient/glow layers, per-theme lightweight particle styles (confetti, sparkles, hearts, dots, glow-pulse, line shimmer), mobile hardening (reduced blur/particles <480px), and GPU-friendly transform/opacity-only animations. 
- Updated upload UI and logic to use shared resolver and expose new theme choices in `client/upload.html` and `client/js/upload.js` without changing gift submission semantics. 
- Added the AR preparation anchor comment in the spotlight (`// FUTURE AR SURFACE ANCHOR`) and ensured spotlight container uses `position: relative` / `isolation: isolate` via CSS to prepare for future WebXR integration. 

### Testing
- Static JS syntax checks passed with `node --check client/js/view.js`, `node --check client/js/upload.js`, `node --check client/utils/themeResolver.js`, and `node --check client/utils/themeConfig.js` (all succeeded). 
- Served the `client/` directory with `python3 -m http.server` and exercised the result page using a Playwright script that mocked the gifts API response and captured a mobile screenshot; the visual smoke test completed and a screenshot artifact was produced. 
- Manual in-browser checks confirmed no changes to gift loading flow and that particle animations are disabled when `animationSpeed` is `0` (corporate/default) and reduced on small screens.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d90e1c6788329b09f86db3a67e196)