### PR TITLE
Fix gift view dynamic loading, theme application, and birthday animation

### DIFF
--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -883,6 +883,31 @@ body.theme-corporate .gift-spotlight::after {
     box-shadow: 0 14px 42px color-mix(in srgb, var(--gift-theme-primary) 22%, transparent);
   }
 }
+
+
+body.is-loading-gift .gift-message {
+  opacity: 0.45;
+}
+
+body.birthday-theme,
+body.wedding-theme,
+body.corporate-theme,
+body.love-theme,
+body.festival-theme,
+body.default-theme {
+  min-height: 100vh;
+}
+
+body.birthday-theme .particles-confetti .view-particles__dot {
+  animation-timing-function: cubic-bezier(0.2, 0.7, 0.25, 1);
+}
+
+@media (max-width: 479px) {
+  body.birthday-theme .view-particles__dot {
+    width: 6px;
+    height: 6px;
+  }
+}
 .theme-preview[data-theme="wedding"] .theme-preview__card {
   background: linear-gradient(135deg, #d4af37, #8f6c29);
 }

--- a/client/js/view.js
+++ b/client/js/view.js
@@ -5,12 +5,28 @@ const messageEl = document.getElementById('giftMessage');
 const videoEl = document.getElementById('videoPlayer');
 const spotlightEl = document.getElementById('giftSpotlight');
 
-const params = new URLSearchParams(window.location.search);
-const id = params.get('id');
+let activeCategory = 'default';
 
 function setStatus(message, isError = false) {
   statusEl.textContent = message;
   statusEl.classList.toggle('error', isError);
+}
+
+function setLoadingState(isLoading) {
+  document.body.classList.toggle('is-loading-gift', isLoading);
+  if (isLoading) {
+    setStatus('Loading your gift...');
+  }
+}
+
+function getGiftIdFromUrl() {
+  const pathSegments = window.location.pathname.split('/').filter(Boolean);
+  if (pathSegments.length >= 2 && pathSegments[pathSegments.length - 2] === 'gift') {
+    return pathSegments[pathSegments.length - 1];
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  return params.get('id') || '';
 }
 
 function getTheme(themeName) {
@@ -66,8 +82,15 @@ function createParticles(themeName, themeToken) {
     const particle = document.createElement('span');
     particle.className = 'view-particles__dot';
     particle.style.left = `${Math.random() * 100}%`;
-    particle.style.animationDelay = `${Math.random() * themeToken.animationSpeed}s`;
-    particle.style.animationDuration = `${themeToken.animationSpeed + (Math.random() * 4 - 2)}s`;
+
+    if (themeName === 'birthday') {
+      particle.style.animationDelay = `${0.22 * i + Math.random() * 0.35}s`;
+      particle.style.animationDuration = `${themeToken.animationSpeed + 6 + Math.random() * 4}s`;
+    } else {
+      particle.style.animationDelay = `${Math.random() * themeToken.animationSpeed}s`;
+      particle.style.animationDuration = `${themeToken.animationSpeed + (Math.random() * 4 - 2)}s`;
+    }
+
     particle.style.setProperty('--particle-sway', `${(Math.random() * 24 - 12).toFixed(1)}px`);
     layer.appendChild(particle);
   }
@@ -77,17 +100,26 @@ function runEntrySequence() {
   document.body.classList.remove('experience-bg-visible', 'experience-particles-visible', 'experience-card-visible', 'experience-message-visible');
 
   window.setTimeout(() => document.body.classList.add('experience-bg-visible'), 0);
-  window.setTimeout(() => document.body.classList.add('experience-particles-visible'), 200);
-  window.setTimeout(() => document.body.classList.add('experience-card-visible'), 400);
-  window.setTimeout(() => document.body.classList.add('experience-message-visible'), 600);
+  window.setTimeout(() => document.body.classList.add('experience-particles-visible'), 220);
+  window.setTimeout(() => document.body.classList.add('experience-card-visible'), 440);
+  window.setTimeout(() => document.body.classList.add('experience-message-visible'), 680);
 }
 
 function applyThemeExperience(theme) {
   const { name, config } = getTheme(theme);
+  activeCategory = name;
 
-  document.body.classList.add('viewer-experience');
-  document.body.classList.remove(...(window.GIFT_THEME_CLASS_LIST || []));
-  document.body.classList.add(`theme-${name}`);
+  const categoryClassMap = {
+    birthday: 'birthday-theme',
+    wedding: 'wedding-theme',
+    corporate: 'corporate-theme',
+    love: 'love-theme',
+    festival: 'festival-theme',
+    default: 'default-theme'
+  };
+
+  const categoryClass = categoryClassMap[name] || categoryClassMap.default;
+  document.body.className = `viewer-experience ${categoryClass} theme-${name}`;
   document.body.dataset.giftTheme = name;
 
   document.body.style.setProperty('--gift-theme-primary', config.primary);
@@ -119,17 +151,21 @@ function resolveMediaUrl(videoUrl) {
 }
 
 async function loadGift() {
+  const id = getGiftIdFromUrl();
+
   if (!id) {
     setStatus('Missing gift link. Please scan a valid QR code.', true);
     return;
   }
 
+  setLoadingState(true);
+
   try {
-    const data = await window.fetchJson(`/gifts/${encodeURIComponent(id)}`);
+    const data = await window.fetchJson(`/gift/${encodeURIComponent(id)}`);
+    const message = data?.enhancedMessage || data?.message || 'A surprise gift is waiting for you.';
 
-    messageEl.textContent = data.message;
-
-    applyThemeExperience(data.theme);
+    messageEl.textContent = message;
+    applyThemeExperience(data?.theme || 'default');
 
     if (data.videoUrl) {
       videoEl.src = resolveMediaUrl(data.videoUrl);
@@ -141,8 +177,17 @@ async function loadGift() {
       spotlightEl.classList.add('reveal-active');
     }
   } catch (error) {
+    console.error('[gift-view] Failed to load gift:', error);
     setStatus(error.message || 'Unable to load this gift.', true);
+    applyThemeExperience('default');
+  } finally {
+    setLoadingState(false);
   }
 }
 
-loadGift();
+window.addEventListener('DOMContentLoaded', loadGift);
+window.smartQRGiftView = {
+  get category() {
+    return activeCategory;
+  }
+};

--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,7 @@ const cors = require('cors');
 const mongoose = require('mongoose');
 const giftRoutes = require('./routes/giftRoutes');
 const Gift = require('./models/Gift');
-const { buildGiftLookupQuery } = require('./controllers/giftController');
+const { buildGiftLookupQuery, getGift } = require('./controllers/giftController');
 
 const app = express();
 app.set('trust proxy', 1);
@@ -262,6 +262,14 @@ app.get('/gift/:publicId', async (req, res) => {
     console.error('[gift] Failed to render gift page:', error);
     return res.status(404).type('html').send(renderNotFoundPage());
   }
+});
+
+
+app.get('/api/gift/:publicId', (req, res, next) => {
+  if (!mongoReady) {
+    return res.status(503).json({ error: 'Database is not connected yet. Please retry shortly.' });
+  }
+  return getGift(req, res, next);
 });
 
 /* -------------------- Mongo guard -------------------- */


### PR DESCRIPTION
### Motivation
- The gift page opened in a new tab but did not fetch gift data, so themes, animations and media never applied and the page remained static.
- The goal was to make the gift view self-contained and dynamic, resolving gift id from both path and query, fetching backend data, applying theme and triggering animations reliably.

### Description
- Frontend: replaced `client/js/view.js` logic to extract `giftId` from `/gift/:id` (with `?id=` fallback), fetch the gift payload on `DOMContentLoaded`, show a loading state, handle errors gracefully, render message/media, and store the resolved category in `window.smartQRGiftView.category`.
- The theme application now maps categories to explicit body classes (`birthday-theme`, `wedding-theme`, `corporate-theme`, `love-theme`, `festival-theme`) while keeping existing `theme-*` classes and CSS vars for visual continuity.
- Birthday particle behavior was improved by adding staggered confetti delays, longer durations, eased timing, and mobile-optimized particle sizing, plus a small loading visual dimming; these changes were added in `client/css/styles.css`.
- Backend: added a compatibility endpoint `GET /api/gift/:publicId` in `server/server.js` that delegates to the existing `getGift` controller so the frontend can fetch the singular route the view expects.

### Testing
- Ran static checks: `node --check client/js/view.js` which completed successfully.
- Ran static checks: `node --check server/server.js` which completed successfully.
- Executed an automated Playwright script that opened the local `/view.html?id=demo` page (mobile viewport) and captured a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d94ce2ba08329a79be4c5cc7497f1)