### PR TITLE
Add Phase 1 WebAR MVP with AR launch from gift viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,29 @@ Render gift page experience.
 - Neural TTS integration
 - Theme packs + seasonal animations
 - Gift analytics + campaign templates
+
+
+## 🧭 WebAR Gift Viewer (Phase 1 MVP)
+
+Gift reveal pages now include a **🎥 View in AR** button that deep-links to `ar.html?giftId=<id>`.
+
+### Run locally
+
+```bash
+npm install
+npm run dev
+```
+
+Then open:
+
+- Standard gift view: `http://localhost:5000/view.html?id=<giftId>`
+- AR view: `http://localhost:5000/ar.html?giftId=<giftId>`
+- Alternate nested AR path (embed-friendly): `http://localhost:5000/ar/ar.html?giftId=<giftId>`
+
+### WebAR notes
+
+- Uses **WebXR hit-test + Three.js** with lazy loading for mobile AR surface placement.
+- Supports image, GIF, and video textured planes.
+- Video is autoplay, muted, and looped for mobile compatibility.
+- Includes permission denial + unsupported-browser fallback overlays.
+

--- a/client/ar.html
+++ b/client/ar.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>View Gift in AR | Smart QR Gifting</title>
+  <link rel="stylesheet" href="css/ar.css" />
+</head>
+<body>
+  <main class="ar-app" id="arApp">
+    <section class="ar-overlay ar-overlay--top" aria-live="polite">
+      <p class="ar-status" id="arStatus">Loading AR…</p>
+      <p class="ar-hint" id="arHint">Move phone slowly</p>
+    </section>
+
+    <section class="ar-overlay ar-overlay--center" id="arTapHint" hidden>
+      <button class="ar-place-btn" id="arPlaceBtn" type="button">Tap to place gift</button>
+    </section>
+
+    <section class="ar-overlay ar-overlay--bottom">
+      <a class="ar-back-link" id="arBackLink" href="view.html">← Back to gift</a>
+    </section>
+
+    <section class="ar-fallback" id="arFallback" hidden>
+      <h1>AR unavailable on this device</h1>
+      <p id="arFallbackMessage">Please use a modern mobile browser with camera permissions enabled.</p>
+      <a class="ar-fallback-link" id="arFallbackViewLink" href="view.html">Open standard gift view</a>
+    </section>
+  </main>
+
+  <script src="js/config.js"></script>
+  <script type="module" src="js/ar.js"></script>
+</body>
+</html>

--- a/client/ar/ar.html
+++ b/client/ar/ar.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>View Gift in AR | Smart QR Gifting</title>
+  <link rel="stylesheet" href="../css/ar.css" />
+</head>
+<body>
+  <main class="ar-app" id="arApp">
+    <section class="ar-overlay ar-overlay--top" aria-live="polite">
+      <p class="ar-status" id="arStatus">Loading AR…</p>
+      <p class="ar-hint" id="arHint">Move phone slowly</p>
+    </section>
+
+    <section class="ar-overlay ar-overlay--center" id="arTapHint" hidden>
+      <button class="ar-place-btn" id="arPlaceBtn" type="button">Tap to place gift</button>
+    </section>
+
+    <section class="ar-overlay ar-overlay--bottom">
+      <a class="ar-back-link" id="arBackLink" href="../view.html">← Back to gift</a>
+    </section>
+
+    <section class="ar-fallback" id="arFallback" hidden>
+      <h1>AR unavailable on this device</h1>
+      <p id="arFallbackMessage">Please use a modern mobile browser with camera permissions enabled.</p>
+      <a class="ar-fallback-link" id="arFallbackViewLink" href="../view.html">Open standard gift view</a>
+    </section>
+  </main>
+
+  <script src="../js/config.js"></script>
+  <script type="module" src="../js/ar.js"></script>
+</body>
+</html>

--- a/client/css/ar.css
+++ b/client/css/ar.css
@@ -1,0 +1,100 @@
+:root {
+  --ar-bg: #02040a;
+  --ar-overlay: rgba(6, 10, 18, 0.72);
+  --ar-border: rgba(255, 255, 255, 0.24);
+  --ar-text: #f9fafb;
+  --ar-accent: #fbbf24;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; width: 100%; height: 100%; background: var(--ar-bg); }
+body { font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: var(--ar-text); }
+
+.ar-app {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  background: radial-gradient(circle at top, rgba(251, 191, 36, 0.15), transparent 40%), #02040a;
+}
+
+.ar-overlay {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  width: min(92vw, 580px);
+}
+
+.ar-overlay--top {
+  top: max(10px, env(safe-area-inset-top));
+  background: var(--ar-overlay);
+  border: 1px solid var(--ar-border);
+  border-radius: 14px;
+  backdrop-filter: blur(10px);
+  padding: 0.75rem 0.9rem;
+}
+
+.ar-overlay--center {
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: grid;
+  place-items: center;
+}
+
+.ar-overlay--bottom {
+  bottom: max(16px, env(safe-area-inset-bottom));
+  display: flex;
+  justify-content: center;
+}
+
+.ar-status { margin: 0; font-weight: 700; }
+.ar-hint { margin: 0.3rem 0 0; color: #d1d5db; font-size: 0.95rem; }
+
+.ar-place-btn,
+.ar-back-link,
+.ar-fallback-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--ar-border);
+  text-decoration: none;
+  color: #fff;
+  background: rgba(15, 23, 42, 0.82);
+  font-weight: 700;
+}
+
+.ar-place-btn {
+  border-color: rgba(251, 191, 36, 0.7);
+  background: linear-gradient(135deg, #fbbf24, #f97316);
+  color: #1a0f04;
+  box-shadow: 0 10px 24px rgba(249, 115, 22, 0.28);
+}
+
+.ar-fallback {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-content: center;
+  gap: 0.8rem;
+  text-align: center;
+  padding: 1rem;
+  background: rgba(2, 4, 10, 0.92);
+}
+
+.ar-fallback h1,
+.ar-fallback p {
+  margin: 0;
+}
+
+.ar-webxr-canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+@media (max-width: 480px) {
+  .ar-status { font-size: 0.96rem; }
+  .ar-hint { font-size: 0.86rem; }
+}

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -917,3 +917,37 @@ body.birthday-theme .particles-confetti .view-particles__dot {
 .theme-preview[data-theme="surprise"] .theme-preview__card {
   background: linear-gradient(135deg, #7c3aed, #4c1d95);
 }
+
+.gift-ar-cta {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+}
+
+.gift-ar-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0.8rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--gift-theme-primary, #8b5cf6) 58%, #fff);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--gift-theme-primary, #8b5cf6) 72%, #fff), color-mix(in srgb, var(--gift-theme-secondary, #c4b5fd) 90%, #111));
+  color: #101322;
+  font-weight: 800;
+  text-decoration: none;
+  letter-spacing: 0.01em;
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--gift-theme-primary, #8b5cf6) 30%, transparent);
+}
+
+.gift-ar-button:hover,
+.gift-ar-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 36px color-mix(in srgb, var(--gift-theme-primary, #8b5cf6) 44%, transparent);
+}
+
+@media (max-width: 480px) {
+  .gift-ar-button {
+    width: 100%;
+  }
+}

--- a/client/js/ar.js
+++ b/client/js/ar.js
@@ -1,0 +1,305 @@
+const statusEl = document.getElementById('arStatus');
+const hintEl = document.getElementById('arHint');
+const placeHintEl = document.getElementById('arTapHint');
+const placeBtn = document.getElementById('arPlaceBtn');
+const fallbackEl = document.getElementById('arFallback');
+const fallbackMessageEl = document.getElementById('arFallbackMessage');
+const fallbackViewLinkEl = document.getElementById('arFallbackViewLink');
+const backLinkEl = document.getElementById('arBackLink');
+
+const state = {
+  giftId: '',
+  media: null,
+  renderer: null,
+  scene: null,
+  camera: null,
+  reticle: null,
+  hitTestSource: null,
+  hitTestSourceRequested: false,
+  surfaceDetected: false,
+  placed: false,
+  giftMesh: null
+};
+
+function setStatus(message) {
+  if (statusEl) statusEl.textContent = message;
+}
+
+function setHint(message) {
+  if (hintEl) hintEl.textContent = message;
+}
+
+function showFallback(message) {
+  if (fallbackMessageEl) {
+    fallbackMessageEl.textContent = message;
+  }
+  if (fallbackEl) {
+    fallbackEl.hidden = false;
+  }
+  setStatus('AR unavailable');
+  setHint('Open gift in standard mode');
+}
+
+function readGiftId() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('giftId') || params.get('id') || '';
+}
+
+function resolveMediaUrl(url) {
+  if (!url) return '';
+  if (url.startsWith('http://') || url.startsWith('https://')) return url;
+  return `${window.API_BASE.replace(/\/api$/, '')}${url}`;
+}
+
+async function loadGiftData(giftId) {
+  const data = await window.fetchJson(`/gift/${encodeURIComponent(giftId)}`);
+  const mediaUrl = data.videoUrl || data.gifUrl || data.imageUrl || '';
+  const mediaType = data.videoUrl ? 'video' : data.gifUrl ? 'gif' : data.imageUrl ? 'image' : '';
+
+  if (!mediaType || !mediaUrl) {
+    throw new Error('This gift does not include media for AR placement yet.');
+  }
+
+  return {
+    mediaType,
+    mediaUrl: resolveMediaUrl(mediaUrl),
+    message: data.enhancedMessage || data.message || ''
+  };
+}
+
+async function getThreeJs() {
+  return import('https://esm.sh/three@0.160.0');
+}
+
+function updateBackLinks(giftId) {
+  const href = `view.html?id=${encodeURIComponent(giftId)}`;
+  if (backLinkEl) backLinkEl.href = href;
+  if (fallbackViewLinkEl) fallbackViewLinkEl.href = href;
+}
+
+async function createMediaTexture(THREE, media) {
+  if (media.mediaType === 'video') {
+    const video = document.createElement('video');
+    video.src = media.mediaUrl;
+    video.crossOrigin = 'anonymous';
+    video.loop = true;
+    video.muted = true;
+    video.playsInline = true;
+    video.autoplay = true;
+    video.preload = 'auto';
+
+    try {
+      await video.play();
+    } catch (error) {
+      console.warn('[ar] video autoplay will retry after user gesture', error);
+    }
+
+    const texture = new THREE.VideoTexture(video);
+    texture.colorSpace = THREE.SRGBColorSpace;
+
+    return {
+      texture,
+      ratio: 16 / 9,
+      resume() {
+        video.play().catch(() => {});
+      }
+    };
+  }
+
+  const textureLoader = new THREE.TextureLoader();
+  const imageTexture = await new Promise((resolve, reject) => {
+    textureLoader.load(media.mediaUrl, resolve, undefined, reject);
+  });
+
+  imageTexture.colorSpace = THREE.SRGBColorSpace;
+  const image = imageTexture.image;
+  const ratio = image && image.width && image.height ? image.width / image.height : 1;
+
+  return {
+    texture: imageTexture,
+    ratio
+  };
+}
+
+async function initArSession() {
+  setStatus('Loading AR…');
+  setHint('Move phone slowly');
+
+  if (!navigator.xr) {
+    showFallback('WebXR is not available. Use Android Chrome or iOS Safari with WebXR support.');
+    return;
+  }
+
+  const supported = await navigator.xr.isSessionSupported('immersive-ar');
+  if (!supported) {
+    showFallback('AR session is unsupported on this browser/device.');
+    return;
+  }
+
+  const THREE = await getThreeJs();
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+  renderer.xr.enabled = true;
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.domElement.classList.add('ar-webxr-canvas');
+  document.body.appendChild(renderer.domElement);
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera();
+
+  const hemiLight = new THREE.HemisphereLight(0xffffff, 0xbbbbff, 0.85);
+  scene.add(hemiLight);
+
+  const dirLight = new THREE.DirectionalLight(0xffffff, 0.75);
+  dirLight.position.set(1, 2, 1);
+  scene.add(dirLight);
+
+  const reticle = new THREE.Mesh(
+    new THREE.RingGeometry(0.12, 0.16, 32).rotateX(-Math.PI / 2),
+    new THREE.MeshBasicMaterial({ color: 0xfbbf24 })
+  );
+  reticle.matrixAutoUpdate = false;
+  reticle.visible = false;
+  scene.add(reticle);
+
+  state.renderer = renderer;
+  state.scene = scene;
+  state.camera = camera;
+  state.reticle = reticle;
+
+  placeBtn?.addEventListener('click', () => {
+    if (state.surfaceDetected && !state.placed) {
+      placeGift(THREE);
+    }
+  });
+
+  const session = await navigator.xr.requestSession('immersive-ar', {
+    requiredFeatures: ['hit-test'],
+    optionalFeatures: ['dom-overlay'],
+    domOverlay: { root: document.body }
+  });
+
+  session.addEventListener('end', () => {
+    state.hitTestSourceRequested = false;
+    state.hitTestSource = null;
+    placeHintEl.hidden = true;
+  });
+
+  renderer.xr.setSession(session);
+  setStatus('Move phone to detect surface');
+
+  renderer.setAnimationLoop((timestamp, frame) => {
+    if (frame) {
+      const referenceSpace = renderer.xr.getReferenceSpace();
+      const sessionNow = renderer.xr.getSession();
+
+      if (!state.hitTestSourceRequested) {
+        sessionNow.requestReferenceSpace('viewer').then((viewerSpace) => {
+          sessionNow.requestHitTestSource({ space: viewerSpace }).then((source) => {
+            state.hitTestSource = source;
+          });
+        });
+        state.hitTestSourceRequested = true;
+      }
+
+      if (state.hitTestSource) {
+        const hitTestResults = frame.getHitTestResults(state.hitTestSource);
+        if (hitTestResults.length > 0 && referenceSpace) {
+          const hit = hitTestResults[0];
+          const pose = hit.getPose(referenceSpace);
+
+          if (pose) {
+            state.reticle.visible = !state.placed;
+            state.reticle.matrix.fromArray(pose.transform.matrix);
+            if (!state.surfaceDetected) {
+              state.surfaceDetected = true;
+              setStatus('Surface detected');
+              setHint('Tap to place gift');
+              placeHintEl.hidden = false;
+            }
+          }
+        } else {
+          state.reticle.visible = false;
+          if (!state.placed) {
+            state.surfaceDetected = false;
+            setStatus('Move phone to detect surface');
+            setHint('Move phone slowly');
+            placeHintEl.hidden = true;
+          }
+        }
+      }
+    }
+
+    renderer.render(scene, camera);
+  });
+
+  window.addEventListener('resize', () => {
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  });
+}
+
+async function placeGift(THREE) {
+  if (state.placed || !state.reticle || !state.media) return;
+
+  const { texture, ratio, resume } = await createMediaTexture(THREE, state.media);
+  const width = 0.55;
+  const height = width / Math.max(ratio || 1, 0.35);
+
+  const plane = new THREE.Mesh(
+    new THREE.PlaneGeometry(width, Math.min(height, 0.95)),
+    new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide, transparent: true })
+  );
+
+  const matrix = state.reticle.matrix;
+  plane.position.setFromMatrixPosition(matrix);
+  plane.quaternion.setFromRotationMatrix(matrix);
+  plane.rotateX(-Math.PI / 2);
+
+  state.scene.add(plane);
+  state.giftMesh = plane;
+  state.placed = true;
+  state.reticle.visible = false;
+  placeHintEl.hidden = true;
+  setStatus('Gift placed');
+  setHint('Move around to view it in space');
+
+  if (typeof resume === 'function') {
+    resume();
+  }
+}
+
+async function init() {
+  const giftId = readGiftId();
+  state.giftId = giftId;
+
+  if (!giftId) {
+    showFallback('Missing gift ID. Open AR from a valid gift page.');
+    return;
+  }
+
+  updateBackLinks(giftId);
+
+  try {
+    state.media = await loadGiftData(giftId);
+  } catch (error) {
+    console.error('[ar] failed to load gift data', error);
+    showFallback(error.message || 'Unable to load gift media for AR.');
+    return;
+  }
+
+  try {
+    await initArSession();
+  } catch (error) {
+    console.error('[ar] initialization failed', error);
+
+    if (String(error?.message || '').toLowerCase().includes('permission')) {
+      showFallback('Camera permission denied. Enable camera access and try again.');
+      return;
+    }
+
+    showFallback('Unable to start AR session on this device.');
+  }
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/client/js/view.js
+++ b/client/js/view.js
@@ -4,6 +4,7 @@ const statusEl = document.getElementById('viewerStatus');
 const messageEl = document.getElementById('giftMessage');
 const videoEl = document.getElementById('videoPlayer');
 const spotlightEl = document.getElementById('giftSpotlight');
+const arCtaEl = document.getElementById('giftArCta');
 
 let activeCategory = 'default';
 
@@ -138,6 +139,23 @@ function applyThemeExperience(theme) {
   runEntrySequence();
 }
 
+
+function renderArButton(giftId) {
+  if (!arCtaEl || !giftId) {
+    return;
+  }
+
+  arCtaEl.innerHTML = '';
+
+  const arButton = document.createElement('a');
+  arButton.className = 'gift-ar-button';
+  arButton.href = `ar.html?giftId=${encodeURIComponent(giftId)}`;
+  arButton.setAttribute('aria-label', 'View gift in augmented reality');
+  arButton.textContent = '🎥 View in AR';
+
+  arCtaEl.appendChild(arButton);
+}
+
 function resolveMediaUrl(videoUrl) {
   if (!videoUrl) {
     return '';
@@ -152,6 +170,7 @@ function resolveMediaUrl(videoUrl) {
 
 async function loadGift() {
   const id = getGiftIdFromUrl();
+  renderArButton(id);
 
   if (!id) {
     setStatus('Missing gift link. Please scan a valid QR code.', true);

--- a/client/view.html
+++ b/client/view.html
@@ -16,7 +16,7 @@
         <video id="videoPlayer" class="gift-video hidden" controls playsinline preload="metadata"></video>
         <p id="giftMessage" class="gift-message"></p>
       </div>
-      <!-- // FUTURE AR SURFACE ANCHOR -->
+      <div class="gift-ar-cta" id="giftArCta"></div>
     </section>
   </main>
   <script src="js/config.js"></script>


### PR DESCRIPTION
### Motivation

- Provide a production-quality Phase 1 WebAR experience so recipients can view gift media in real world from the gift result page. 
- Keep the implementation embeddable and lightweight with lazy-loaded AR libraries and clear fallbacks for unsupported devices or denied permissions. 
- Support image/GIF/video media (video prioritized) with mobile-friendly autoplay/loop/muted behavior for an immediate MVP.

### Description

- Add premium AR CTA to the gift result page by injecting a `🎥 View in AR` button that links to `ar.html?giftId=<id>` and is rendered by `client/js/view.js`; DOM anchor added at `client/view.html` and styled in `client/css/styles.css`.
- Add standalone AR entry pages `client/ar.html` and `client/ar/ar.html` that provide the AR UX shell, overlays, and fallback UI for accessibility and embed-friendly routing.
- Implement AR runtime in `client/js/ar.js` which: reads `giftId` from URL, fetches gift data via `window.fetchJson`, lazy-loads Three.js from CDN, starts a `navigator.xr` immersive AR session with hit-test surface detection, shows guidance overlays (`Loading AR…`, `Move phone slowly`, `Surface detected`, `Tap to place gift`), and places an image/GIF/video textured plane into the real world.
- Add AR-specific styles in `client/css/ar.css` (overlays, place button, fallback screen, safe-area handling) and add premium styling for the AR CTA in `client/css/styles.css`.
- Support media textures and mobile video semantics: video elements are created with `playsInline`, `autoplay`, `muted`, and `loop`, and are wrapped in a `THREE.VideoTexture` with a `resume()` helper to re-start playback after user gesture when needed.
- Keep server and API usage unchanged; media URLs are resolved via `window.API_BASE` so there are no hardcoded domains, and no new npm dependencies were added (Three.js is lazy-loaded via CDN at runtime).
- Update `README.md` with local run instructions and AR route notes.

### Testing

- Checked syntax with `node --check client/js/view.js`, `node --check client/js/ar.js`, and `node --check server/server.js`; all checks passed. (✅)
- Started the server with `node server/server.js` to validate routes and capture UI state; server started and served `view.html` and `ar.html` for screenshot verification. (✅)
- `npm run dev` failed in the environment because `nodemon` is not installed, so `node server/server.js` was used instead for verification; this is an environment tool issue and not related to the code changes. (⚠️)
- Captured automated UI screenshots of the gift page showing the AR CTA and the AR fallback state using Playwright; screenshots produced successfully. (✅)

Files changed or added (high level): `client/view.html`, `client/js/view.js`, `client/css/styles.css`, `client/ar.html`, `client/ar/ar.html`, `client/js/ar.js`, `client/css/ar.css`, `README.md`.

If you want, I can (1) swap the CDN import to a chosen bundled release, (2) add an optional build step to vendor Three.js for offline hosting, or (3) wire an analytics event when users open the AR view.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9c2cae048329b87f90b55569f653)